### PR TITLE
Rename Point class

### DIFF
--- a/lib/src/core/bounds.dart
+++ b/lib/src/core/bounds.dart
@@ -2,10 +2,10 @@ import 'dart:math' as math;
 import 'point.dart';
 
 class Bounds<T extends num> {
-  final Point<T> min;
-  final Point<T> max;
+  final CustomPoint<T> min;
+  final CustomPoint<T> max;
 
-  factory Bounds(Point<T> a, Point<T> b) {
+  factory Bounds(CustomPoint<T> a, CustomPoint<T> b) {
     var bounds1 = new Bounds._(a, b);
     var bounds2 = bounds1.extend(a);
     return bounds2.extend(b);
@@ -13,9 +13,9 @@ class Bounds<T extends num> {
 
   const Bounds._(this.min, this.max);
 
-  Bounds<T> extend(Point<T> point) {
-    Point<T> newMin;
-    Point<T> newMax;
+  Bounds<T> extend(CustomPoint<T> point) {
+    CustomPoint<T> newMin;
+    CustomPoint<T> newMax;
     if (this.min == null && this.max == null) {
       newMin = point;
       newMax = point;
@@ -24,29 +24,29 @@ class Bounds<T extends num> {
       var maxX = math.max(point.x, this.max.x);
       var minY = math.min(point.y, this.min.y);
       var maxY = math.max(point.y, this.max.y);
-      newMin = new Point(minX, minY);
-      newMax = new Point(maxX, maxY);
+      newMin = new CustomPoint(minX, minY);
+      newMax = new CustomPoint(maxX, maxY);
     }
     return new Bounds._(newMin, newMax);
   }
 
-  Point<double> getCenter() {
-    return new Point<double>(
+  CustomPoint<double> getCenter() {
+    return new CustomPoint<double>(
       (min.x + max.x) / 2,
       (min.y + max.y) / 2,
     );
   }
 
-  Point<T> get bottomLeft => new Point(min.x, max.y);
-  Point<T> get topRight => new Point(max.x, min.y);
-  Point<T> get topLeft => min;
-  Point<T> get bottomRight => max;
+  CustomPoint<T> get bottomLeft => new CustomPoint(min.x, max.y);
+  CustomPoint<T> get topRight => new CustomPoint(max.x, min.y);
+  CustomPoint<T> get topLeft => min;
+  CustomPoint<T> get bottomRight => max;
 
-  Point<T> get size {
+  CustomPoint<T> get size {
     return this.max - this.min;
   }
 
-  bool contains(Point<T> point) {
+  bool contains(CustomPoint<T> point) {
     var min = point;
     var max = point;
     return containsBounds(new Bounds(min, max));

--- a/lib/src/core/point.dart
+++ b/lib/src/core/point.dart
@@ -1,48 +1,48 @@
 import 'dart:math' as math;
 
-class Point<T extends num> extends math.Point<T> {
-  const Point(num x, num y) : super(x, y);
+class CustomPoint<T extends num> extends math.Point<T> {
+  const CustomPoint(num x, num y) : super(x, y);
 
-  Point<T> operator /(num /*T|int*/ factor) {
-    return new Point<T>(x / factor, y / factor);
+  CustomPoint<T> operator /(num /*T|int*/ factor) {
+    return new CustomPoint<T>(x / factor, y / factor);
   }
 
-  Point<T> ceil() {
-    return new Point(x.ceil(), y.ceil());
+  CustomPoint<T> ceil() {
+    return new CustomPoint(x.ceil(), y.ceil());
   }
 
-  Point<T> floor() {
-    return new Point<T>(x.floor(), y.floor());
+  CustomPoint<T> floor() {
+    return new CustomPoint<T>(x.floor(), y.floor());
   }
 
-  Point<T> unscaleBy(Point<T> point) {
-    return new Point<T>(x / point.x, y / point.y);
+  CustomPoint<T> unscaleBy(CustomPoint<T> point) {
+    return new CustomPoint<T>(x / point.x, y / point.y);
   }
 
-  Point<T> operator +(math.Point<T> other) {
-    return new Point<T>(x + other.x, y + other.y);
+  CustomPoint<T> operator +(math.Point<T> other) {
+    return new CustomPoint<T>(x + other.x, y + other.y);
   }
 
-  Point<T> operator -(math.Point<T> other) {
-    return new Point<T>(x - other.x, y - other.y);
+  CustomPoint<T> operator -(math.Point<T> other) {
+    return new CustomPoint<T>(x - other.x, y - other.y);
   }
 
-  Point<T> operator *(num /*T|int*/ factor) {
-    return new Point<T>((x * factor), (y * factor));
+  CustomPoint<T> operator *(num /*T|int*/ factor) {
+    return new CustomPoint<T>((x * factor), (y * factor));
   }
 
-  Point scaleBy(Point point) {
-    return new Point(this.x * point.x, this.y * point.y);
+  CustomPoint scaleBy(CustomPoint point) {
+    return new CustomPoint(this.x * point.x, this.y * point.y);
   }
 
-  Point round() {
+  CustomPoint round() {
     var x = this.x is double ? this.x.round() : this.x;
     var y = this.y is double ? this.y.round() : this.y;
-    return new Point(x, y);
+    return new CustomPoint(x, y);
   }
 
-  Point multiplyBy(num n) {
-      return new Point(this.x * n, this.y * n);
+  CustomPoint multiplyBy(num n) {
+      return new CustomPoint(this.x * n, this.y * n);
   }
 
   String toString() => "Point ($x, $y)";

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -13,17 +13,17 @@ abstract class Crs {
 
   const Crs();
 
-  Point latLngToPoint(LatLng latlng, double zoom) {
+  CustomPoint latLngToPoint(LatLng latlng, double zoom) {
     try {
       var projectedPoint = this.projection.project(latlng);
       var scale = this.scale(zoom);
       return transformation.transform(projectedPoint, scale.toDouble());
     } catch (e) {
-      return new Point(0.0, 0.0);
+      return new CustomPoint(0.0, 0.0);
     }
   }
 
-  LatLng pointToLatLng(Point point, double zoom) {
+  LatLng pointToLatLng(CustomPoint point, double zoom) {
     var scale = this.scale(zoom);
     var untransformedPoint = this.transformation.untransform(point, scale.toDouble());
     try {
@@ -79,8 +79,8 @@ abstract class Projection {
   const Projection();
 
   Bounds<double> get bounds;
-  Point project(LatLng latlng);
-  LatLng unproject(Point point);
+  CustomPoint project(LatLng latlng);
+  LatLng unproject(CustomPoint point);
 }
 
 class SphericalMercator extends Projection {
@@ -88,25 +88,25 @@ class SphericalMercator extends Projection {
   static const double maxLatitude = 85.0511287798;
   static const double _boundsD = r * math.pi;
   static Bounds<double> _bounds = new Bounds<double>(
-    new Point<double>(-_boundsD, -_boundsD),
-    new Point<double>(_boundsD, _boundsD),
+    new CustomPoint<double>(-_boundsD, -_boundsD),
+    new CustomPoint<double>(_boundsD, _boundsD),
   );
 
   const SphericalMercator() : super();
 
   Bounds<double> get bounds => _bounds;
 
-  Point project(LatLng latlng) {
+  CustomPoint project(LatLng latlng) {
     var d = math.pi / 180;
     var max = maxLatitude;
     var lat = math.max(math.min(max, latlng.latitude), -max);
     var sin = math.sin(lat * d);
 
-    return new Point(
+    return new CustomPoint(
         r * latlng.longitude * d, r * math.log((1 + sin) / (1 - sin)) / 2);
   }
 
-  LatLng unproject(Point point) {
+  LatLng unproject(CustomPoint point) {
     var d = 180 / math.pi;
     return new LatLng(
         (2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d,
@@ -121,21 +121,21 @@ class Transformation {
   final num d;
   const Transformation(this.a, this.b, this.c, this.d);
 
-  Point transform(Point<num> point, double scale) {
+  CustomPoint transform(CustomPoint<num> point, double scale) {
     if (scale == null) {
       scale = 1.0;
     }
     var x = scale * (a * point.x + b);
     var y = scale * (c * point.y + d);
-    return new Point(x, y);
+    return new CustomPoint(x, y);
   }
 
-  Point untransform(Point point, double scale) {
+  CustomPoint untransform(CustomPoint point, double scale) {
     if (scale == null) {
       scale = 1.0;
     }
     var x = (point.x / scale - b) / a;
     var y = (point.y / scale - d) / c;
-    return new Point(x, y);
+    return new CustomPoint(x, y);
   }
 }

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -14,7 +14,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   LatLng _mapCenterStart;
   double _mapZoomStart;
   LatLng _focalStartGlobal;
-  Point _focalStartLocal;
+  CustomPoint _focalStartLocal;
 
   AnimationController _controller;
   Animation<Offset> _flingAnimation;
@@ -97,7 +97,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     // convert the point to global coordinates
     var localPoint = _offsetToPoint(offset);
     var localPointCenterDistance =
-        new Point((width / 2) - localPoint.x, (height / 2) - localPoint.y);
+        new CustomPoint((width / 2) - localPoint.x, (height / 2) - localPoint.y);
     var mapCenter = map.project(map.center);
     var point = mapCenter - localPointCenterDistance;
     return map.unproject(point);
@@ -158,17 +158,17 @@ abstract class MapGestureMixin extends State<FlutterMap>
     setState(() {
       _flingOffset = _flingAnimation.value;
       var newCenterPoint = map.project(_mapCenterStart) +
-          new Point(_flingOffset.dx, _flingOffset.dy);
+          new CustomPoint(_flingOffset.dx, _flingOffset.dy);
       var newCenter = map.unproject(newCenterPoint);
       map.move(newCenter, map.zoom, hasGesture: true);
     });
   }
 
-  Point _offsetToPoint(Offset offset) {
-    return new Point(offset.dx, offset.dy);
+  CustomPoint _offsetToPoint(Offset offset) {
+    return new CustomPoint(offset.dx, offset.dy);
   }
 
-  Offset _pointToOffset(Point point) {
+  Offset _pointToOffset(CustomPoint point) {
     return new Offset(point.x.toDouble(), point.y.toDouble());
   }
 

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -201,7 +201,7 @@ class _TileLayerState extends State<TileLayer> {
       if (newOrigin != null) {
         level.origin = newOrigin;
       } else {
-        level.origin = new Point(0.0, 0.0);
+        level.origin = new CustomPoint(0.0, 0.0);
       }
       level.zoom = zoom;
 
@@ -217,12 +217,12 @@ class _TileLayerState extends State<TileLayer> {
     var tileRange = _pxBoundsToTileRange(pixelBounds);
     var margin = this.options.keepBuffer ?? 2;
     var noPruneRange = new Bounds(
-        tileRange.bottomLeft - new Point(margin, -margin),
-        tileRange.topRight + new Point(margin, -margin));
+        tileRange.bottomLeft - new CustomPoint(margin, -margin),
+        tileRange.topRight + new CustomPoint(margin, -margin));
     for (var tileKey in _tiles.keys) {
       var tile = _tiles[tileKey];
       var c = tile.coords;
-      if (c.z != _tileZoom || !noPruneRange.contains(new Point(c.x, c.y))) {
+      if (c.z != _tileZoom || !noPruneRange.contains(new CustomPoint(c.x, c.y))) {
         tile.current = false;
       }
     }
@@ -313,14 +313,14 @@ class _TileLayerState extends State<TileLayer> {
     return zoom;
   }
 
-  Point getTileSize() {
-    return new Point(options.tileSize, options.tileSize);
+  CustomPoint getTileSize() {
+    return new CustomPoint(options.tileSize, options.tileSize);
   }
 
   Widget build(BuildContext context) {
     var pixelBounds = _getTiledPixelBounds(map.center);
     var tileRange = _pxBoundsToTileRange(pixelBounds);
-    Point<double> tileCenter = tileRange.getCenter();
+    CustomPoint<double> tileCenter = tileRange.getCenter();
     var queue = <Coords>[];
 
     // mark tiles as out of view...
@@ -392,7 +392,7 @@ class _TileLayerState extends State<TileLayer> {
     var tileSize = this.getTileSize();
     return new Bounds(
       bounds.min.unscaleBy(tileSize).floor(),
-      bounds.max.unscaleBy(tileSize).ceil() - new Point(1, 1),
+      bounds.max.unscaleBy(tileSize).ceil() - new CustomPoint(1, 1),
     );
   }
 
@@ -466,7 +466,7 @@ class _TileLayerState extends State<TileLayer> {
     return newCoords;
   }
 
-  Point _getTilePos(Coords coords) {
+  CustomPoint _getTilePos(Coords coords) {
     var level = _levels[coords.z];
     return coords.scaleBy(this.getTileSize()) - level.origin;
   }
@@ -490,13 +490,13 @@ class Tile {
 class Level {
   List children = [];
   double zIndex;
-  Point origin;
+  CustomPoint origin;
   double zoom;
-  Point translatePoint;
+  CustomPoint translatePoint;
   double scale;
 }
 
-class Coords<T extends num> extends Point<T> {
+class Coords<T extends num> extends CustomPoint<T> {
   T z;
 
   Coords(T x, T y) : super(x, y);

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -49,7 +49,7 @@ class FlutterMapState extends MapGestureMixin {
     return new LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
       mapState.size =
-          new Point<double>(constraints.maxWidth, constraints.maxHeight);
+          new CustomPoint<double>(constraints.maxWidth, constraints.maxHeight);
       var layerWidgets = widget.layers
           .map((layer) => _createLayer(layer, widget.options.plugins))
           .toList();

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -53,18 +53,18 @@ class MapState {
 
   LatLng _lastCenter;
   LatLngBounds _lastBounds;
-  Point _pixelOrigin;
+  CustomPoint _pixelOrigin;
   bool _initialized = false;
 
   MapState(this.options) : _onMoveSink = new StreamController.broadcast();
 
-  Point _size;
+  CustomPoint _size;
 
   Stream<Null> get onMoved => _onMoveSink.stream;
 
-  Point get size => _size;
+  CustomPoint get size => _size;
 
-  set size(Point s) {
+  set size(CustomPoint s) {
     _size = s;
     _pixelOrigin = getNewPixelOrigin(_lastCenter);
     if (!_initialized) {
@@ -156,9 +156,9 @@ class MapState {
 
   CenterZoom _getBoundsCenterZoom(
       LatLngBounds bounds, FitBoundsOptions options) {
-    var paddingTL = Point<double>(options.padding.left, options.padding.top);
+    var paddingTL = CustomPoint<double>(options.padding.left, options.padding.top);
     var paddingBR =
-        Point<double>(options.padding.right, options.padding.bottom);
+        CustomPoint<double>(options.padding.right, options.padding.bottom);
 
     var paddingTotalXY = paddingTL + paddingBR;
 
@@ -175,7 +175,7 @@ class MapState {
     );
   }
 
-  double getBoundsZoom(LatLngBounds bounds, Point<double> padding,
+  double getBoundsZoom(LatLngBounds bounds, CustomPoint<double> padding,
       {bool inside = false}) {
     var zoom = this.zoom ?? 0.0;
     var min = this.options.minZoom ?? 0.0;
@@ -193,25 +193,25 @@ class MapState {
     return math.max(min, math.min(max, zoom));
   }
 
-  Point project(LatLng latlng, [double zoom]) {
+  CustomPoint project(LatLng latlng, [double zoom]) {
     if (zoom == null) {
       zoom = _zoom;
     }
     return options.crs.latLngToPoint(latlng, zoom);
   }
 
-  LatLng unproject(Point point, [double zoom]) {
+  LatLng unproject(CustomPoint point, [double zoom]) {
     if (zoom == null) {
       zoom = _zoom;
     }
     return options.crs.pointToLatLng(point, zoom);
   }
 
-  LatLng layerPointToLatLng(Point point) {
+  LatLng layerPointToLatLng(CustomPoint point) {
     return unproject(point);
   }
 
-  Point get _centerLayerPoint {
+  CustomPoint get _centerLayerPoint {
     return size / 2;
   }
 
@@ -231,11 +231,11 @@ class MapState {
     return options.crs.getProjectedBounds(zoom == null ? _zoom : zoom);
   }
 
-  Point getPixelOrigin() {
+  CustomPoint getPixelOrigin() {
     return _pixelOrigin;
   }
 
-  Point getNewPixelOrigin(LatLng center, [double zoom]) {
+  CustomPoint getNewPixelOrigin(LatLng center, [double zoom]) {
     var viewHalf = this.size / 2.0;
     return (this.project(center, zoom) - viewHalf).round();
   }
@@ -244,7 +244,7 @@ class MapState {
     var mapZoom = zoom;
     var scale = getZoomScale(mapZoom, zoom);
     var pixelCenter = project(center, zoom).floor();
-    Point<num> halfSize = size / (scale * 2);
+    CustomPoint<num> halfSize = size / (scale * 2);
     return new Bounds(pixelCenter - halfSize, pixelCenter + halfSize);
   }
 }


### PR DESCRIPTION
Rename the class Point to Custompoint so it doesnt interfere with the dart:math Point class. Fixes #185.