### PR TITLE
Keep tiles for a short time before pruning to stop grey screen

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -79,6 +79,13 @@ class TileLayerOptions extends LayerOptions {
   /// When panning the map, keep this many rows and columns of tiles before
   /// unloading them.
   final int keepBuffer;
+
+  /// When transitioning zoom levels, keep for this many milliseconds before discarding
+  /// This helps smooth the blank tiles during a load, when you get a grey screen
+  /// Recommend > 1000 for mobile
+
+  final int keepTileDelay;
+
   ImageProvider placeholderImage;
   Map<String, String> additionalOptions;
 
@@ -95,6 +102,7 @@ class TileLayerOptions extends LayerOptions {
     this.placeholderImage,
     this.offlineMode = false,
     this.fromAssets = true,
+    this.keepTileDelay = 1200,
     rebuild}) : super(rebuild: rebuild);
 }
 
@@ -127,6 +135,7 @@ class _TileLayerState extends State<TileLayer> {
 
   Map<String, Tile> _tiles = {};
   Map<double, Level> _levels = {};
+  Map<String, DateTime> _usedTileCache = {};
 
   void initState() {
     super.initState();
@@ -212,6 +221,7 @@ class _TileLayerState extends State<TileLayer> {
   }
 
   void _pruneTiles() {
+    List<String> toRemove = [];
     var center = map.center;
     var pixelBounds = this._getTiledPixelBounds(center);
     var tileRange = _pxBoundsToTileRange(pixelBounds);
@@ -226,7 +236,18 @@ class _TileLayerState extends State<TileLayer> {
         tile.current = false;
       }
     }
-    _tiles.removeWhere((s, tile) => tile.current == false);
+
+    _tiles.keys.forEach(( tileKey ) {
+      if((_tiles[tileKey].current == false) && (_usedTileCache[tileKey] == null)) {
+        _usedTileCache[tileKey] = DateTime.now();
+      } else if ((_tiles[tileKey].current == false) && ( DateTime.now().difference(_usedTileCache[tileKey]).inMilliseconds > this.options.keepTileDelay)) {
+      toRemove.add(tileKey);
+      }
+    });
+    toRemove.forEach((String tileKey ){
+      _tiles.remove(tileKey);
+      _usedTileCache.remove(tileKey);
+    });
   }
 
   void _setZoomTransform(Level level, LatLng center, double zoom) {
@@ -322,7 +343,6 @@ class _TileLayerState extends State<TileLayer> {
     var tileRange = _pxBoundsToTileRange(pixelBounds);
     Point<double> tileCenter = tileRange.getCenter();
     var queue = <Coords>[];
-
     // mark tiles as out of view...
     for (var key in this._tiles.keys) {
       var c = this._tiles[key].coords;


### PR DESCRIPTION
This helps with grey screen where tiles are pruned before new ones loaded, by adding keepTileDelay = 1200 as an option. It keeps a Map as a cache, with the time it was added, and then after the time set in keepTileDelay removes it from the cache & marks the tile false in _tiles, so it can then get pruned.

I think a better future solution may use a callback instead of a time limit, when the images have finished downloading, before pruning, but I don't see a way to do that currently.