### PR TITLE
Remove layers property from MapOptions #33

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -78,7 +78,6 @@ class MapOptions {
   final double zoom;
   final double minZoom;
   final double maxZoom;
-  final List<LayerOptions> layers;
   final bool debug;
   final bool interactive;
   final TapCallback onTap;
@@ -94,7 +93,6 @@ class MapOptions {
     this.zoom = 13.0,
     this.minZoom,
     this.maxZoom,
-    this.layers,
     this.debug = false,
     this.interactive = true,
     this.onTap,


### PR DESCRIPTION
I did a mistake with this property so probably will be better if we will remove this. 
https://github.com/johnpryan/flutter_map/issues/33 