### PR TITLE
adding cached network image dependency for tiles

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -11,6 +11,7 @@ import 'package:latlong/latlong.dart';
 import 'package:transparent_image/transparent_image.dart';
 import 'package:tuple/tuple.dart';
 import 'package:flutter_image/network.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 import 'layer.dart';
 
@@ -76,6 +77,12 @@ class TileLayerOptions extends LayerOptions {
   ///The later requires permissions to read the device files in Android.
   final bool fromAssets;
 
+  /// Use CachedNetworkImageProvider instead NetworkImageWithRetry
+  /// If true, every tile loaded will be storage on cache memory
+  /// If false, will download every tiles again after every restart the app
+  /// default is true
+  final bool cachedTiles;
+
   /// When panning the map, keep this many rows and columns of tiles before
   /// unloading them.
   final int keepBuffer;
@@ -95,6 +102,7 @@ class TileLayerOptions extends LayerOptions {
     this.placeholderImage,
     this.offlineMode = false,
     this.fromAssets = true,
+    this.cachedTiles = true,
     rebuild}) : super(rebuild: rebuild);
 }
 
@@ -449,7 +457,11 @@ class _TileLayerState extends State<TileLayer> {
         return new FileImage(new File(url));
       }
     } else {
-      return new NetworkImageWithRetry(url);
+      if(options.cachedTiles){
+        return new CachedNetworkImageProvider(url);
+      }else{        
+        return new NetworkImageWithRetry(url);
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,3 +17,4 @@ dependencies:
   transparent_image: ^0.1.0
   async: ^2.0.8
   flutter_image: ^1.0.0
+  cached_network_image: ^0.5.1


### PR DESCRIPTION
#203 
Add option( `cachedTiles=true` ) for use CachedNetworkImageProvider instead NetworkImageWithRetry.
Storage image tiles in cache memory, for keep the images tiles after restart the application even if there is no internet connection.