### PR TITLE
CircleMarker radius in meters and  new overlay image layer

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -16,7 +16,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '28.0.3'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Wed Jan 16 23:15:03 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,6 +10,7 @@ import './pages/tap_to_add.dart';
 import './pages/offline_map.dart';
 import './pages/on_tap.dart';
 import './pages/circle.dart';
+import './pages/overlay_image.dart';
 
 void main() => runApp(new MyApp());
 
@@ -34,6 +35,7 @@ class MyApp extends StatelessWidget {
         OfflineMapPage.route: (context) => new OfflineMapPage(),
         OnTapPage.route: (context) => new OnTapPage(),
         CirclePage.route: (context) => new CirclePage(),
+        OverlayImagePage.route: (context) => new OverlayImagePage(),
       },
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ import './pages/polyline.dart';
 import './pages/tap_to_add.dart';
 import './pages/offline_map.dart';
 import './pages/on_tap.dart';
+import './pages/circle.dart';
 
 void main() => runApp(new MyApp());
 
@@ -32,6 +33,7 @@ class MyApp extends StatelessWidget {
         PluginPage.route: (context) => new PluginPage(),
         OfflineMapPage.route: (context) => new OfflineMapPage(),
         OnTapPage.route: (context) => new OnTapPage(),
+        CirclePage.route: (context) => new CirclePage(),
       },
     );
   }

--- a/example/lib/pages/circle.dart
+++ b/example/lib/pages/circle.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import '../widgets/drawer.dart';
+import 'package:latlong/latlong.dart';
+
+class CirclePage extends StatelessWidget {
+  static const String route = 'circle';
+  Widget build(BuildContext context) {
+    var circleMarkers = <CircleMarker>[
+      new CircleMarker(
+        point: new LatLng(51.5, -0.09),
+        color: Colors.blue.withOpacity(0.7),
+        useRadiusInMeter: true,
+        radius: 2000// 2000 meters | 2 km
+      ),
+    ];
+
+    return new Scaffold(
+      appBar: new AppBar(title: new Text("Circle")),
+      drawer: buildDrawer(context, route),
+      body: new Padding(
+        padding: new EdgeInsets.all(8.0),
+        child: new Column(
+          children: [
+            new Padding(
+              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: new Text("This is a map that is showing (51.5, -0.9)."),
+            ),
+            new Flexible(
+              child: new FlutterMap(
+                options: new MapOptions(
+                  center: new LatLng(51.5, -0.09),
+                  zoom: 11.0,
+                ),
+                layers: [
+                  new TileLayerOptions(
+                      urlTemplate:
+                      "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                      subdomains: ['a', 'b', 'c']),
+                  new CircleLayerOptions(circles: circleMarkers)
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/pages/overlay_image.dart
+++ b/example/lib/pages/overlay_image.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import '../widgets/drawer.dart';
+import 'package:latlong/latlong.dart';
+
+class OverlayImagePage extends StatelessWidget {
+  static const String route = 'overlay_image';
+  Widget build(BuildContext context) {
+    var overlayImages = <OverlayImage>[
+      new OverlayImage(
+        bounds: LatLngBounds(LatLng(51.5, -0.09),LatLng(48.8566, 2.3522)),
+        opacity: 0.8,
+        imageProvider: NetworkImage('https://images.pexels.com/photos/231009/pexels-photo-231009.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=300&w=600')
+      ),
+    ];
+
+    return new Scaffold(
+      appBar: new AppBar(title: new Text("Circle")),
+      drawer: buildDrawer(context, route),
+      body: new Padding(
+        padding: new EdgeInsets.all(8.0),
+        child: new Column(
+          children: [
+            new Padding(
+              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: new Text("This is a map that is showing (51.5, -0.9)."),
+            ),
+            new Flexible(
+              child: new FlutterMap(
+                options: new MapOptions(
+                  center: new LatLng(51.5, -0.09),
+                  zoom: 6.0,
+                ),
+                layers: [
+                  new TileLayerOptions(
+                      urlTemplate:
+                      "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                      subdomains: ['a', 'b', 'c']),
+                  new OverlayImageLayerOptions(overlayImages: overlayImages)
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -9,6 +9,7 @@ import '../pages/plugin_api.dart';
 import '../pages/polyline.dart';
 import '../pages/tap_to_add.dart';
 import '../pages/on_tap.dart';
+import '../pages/circle.dart';
 
 Drawer buildDrawer(BuildContext context, String currentRoute) {
   return new Drawer(
@@ -87,6 +88,13 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           selected: currentRoute == OnTapPage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, OnTapPage.route);
+          },
+        ),
+        new ListTile(
+          title: const Text('Circle'),
+          selected: currentRoute == CirclePage.route,
+          onTap: () {
+            Navigator.pushReplacementNamed(context, CirclePage.route);
           },
         ),
       ],

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -10,6 +10,7 @@ import '../pages/polyline.dart';
 import '../pages/tap_to_add.dart';
 import '../pages/on_tap.dart';
 import '../pages/circle.dart';
+import '../pages/overlay_image.dart';
 
 Drawer buildDrawer(BuildContext context, String currentRoute) {
   return new Drawer(
@@ -95,6 +96,13 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           selected: currentRoute == CirclePage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, CirclePage.route);
+          },
+        ),
+        new ListTile(
+          title: const Text('Overlay Image'),
+          selected: currentRoute == OverlayImagePage.route,
+          onTap: () {
+            Navigator.pushReplacementNamed(context, OverlayImagePage.route);
           },
         ),
       ],

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -20,6 +20,7 @@ export 'src/layer/polyline_layer.dart';
 export 'src/layer/polygon_layer.dart';
 export 'src/layer/circle_layer.dart';
 export 'src/layer/group_layer.dart';
+export 'src/layer/overlay_image_layer.dart';
 export 'src/geo/crs/crs.dart';
 export 'src/geo/latlng_bounds.dart';
 export 'package:flutter_map/src/core/point.dart';

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -17,10 +17,13 @@ class CircleMarker {
   final Color color;
   final double borderStrokeWidth;
   final Color borderColor;
+  final bool useRadiusInMeter;
   Offset offset = Offset.zero;
+  num realRadius = 0;
   CircleMarker({
     this.point,
     this.radius,
+    this.useRadiusInMeter = false,
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
     this.borderColor = const Color(0xFFFFFF00),
@@ -52,6 +55,17 @@ class CircleLayer extends StatelessWidget {
           pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
               map.getPixelOrigin();
           circle.offset = new Offset(pos.x.toDouble(), pos.y.toDouble());
+
+          if(circle.useRadiusInMeter)
+          {
+            var r = Distance().offset(circle.point, circle.radius , 180);
+            var rpos = map.project(r);
+            rpos = rpos .multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
+                map.getPixelOrigin();
+
+            circle.realRadius = rpos.y - pos.y;
+          }
+
           circleWidgets.add(
             new CustomPaint(
               painter: new CirclePainter(circle),
@@ -88,7 +102,7 @@ class CirclePainter extends CustomPainter {
           ..strokeWidth = circle.borderStrokeWidth)
         : null;
 
-    _paintCircle(canvas, circle.offset, circle.radius, paint);
+    _paintCircle(canvas, circle.offset, circle.useRadiusInMeter ? circle.realRadius : circle.radius, paint);
   }
 
   void _paintCircle(Canvas canvas, Offset offset, double radius, Paint paint) {

--- a/lib/src/layer/group_layer.dart
+++ b/lib/src/layer/group_layer.dart
@@ -57,6 +57,10 @@ class GroupLayer extends StatelessWidget {
       return new PolygonLayer(
           options, map, options.rebuild);
     }
+    if (options is OverlayImageLayerOptions) {
+      return new OverlayImageLayer(
+          options, map, options.rebuild);
+    }
     throw ("Unknown options type for GeometryLayer: $options");
   }
 

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+import 'dart:math';
+import 'dart:ui';
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart' as img;
+import 'package:flutter/services.dart' as img;
+import 'package:flutter/widgets.dart' as img;
+import 'package:flutter/painting.dart' as img;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/src/map/map.dart';
+import 'package:latlong/latlong.dart' hide Path;  // conflict with Path from UI
+
+class OverlayImageLayerOptions extends LayerOptions {
+  final List<OverlayImage> overlayImages;
+  OverlayImageLayerOptions({this.overlayImages = const [], rebuild})
+      : super(rebuild: rebuild);
+}
+
+class OverlayImage {
+  final img.ImageProvider imageProvider;
+  final double opacity;
+  final LatLngBounds bounds;
+  final List<Offset> offsets = [];
+  ui.Image image;
+
+  OverlayImage({
+    this.bounds,
+    this.imageProvider,
+    this.opacity = 1.0,
+  });
+}
+
+Future<ui.Image> _loadImage(img.ImageProvider imageProvider) async
+{
+    img.ImageStream stream = imageProvider.resolve(img.ImageConfiguration.empty);
+    Completer<ui.Image> completer = new Completer<ui.Image>();
+    void listener(img.ImageInfo frame, bool synchronousCall) {
+      final ui.Image image = frame.image;
+      completer.complete(image);
+      stream.removeListener(listener);
+    }
+    stream.addListener(listener);
+    return completer.future;
+}
+
+class OverlayImageLayer extends StatelessWidget {
+  final OverlayImageLayerOptions overlayImageOpts;
+  final MapState map;
+  final Stream<Null> stream;
+  
+  OverlayImageLayer(this.overlayImageOpts, this.map, this.stream);
+
+  Widget build(BuildContext context) {
+    return new LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints bc) {
+        final size = new Size(bc.maxWidth, bc.maxHeight);
+        return _build(context, size);
+      },
+    );
+  }
+
+  Widget _build(BuildContext context, Size size) {
+    return new StreamBuilder<int>(
+      stream: stream, // a Stream<int> or null
+      builder: (BuildContext context, _) {
+        for (var overlayImageOpt in overlayImageOpts.overlayImages) {
+          overlayImageOpt.offsets.clear();
+          var pos1 = map.project(overlayImageOpt.bounds.northWest);
+          pos1 = pos1.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
+          var pos2 = map.project(overlayImageOpt.bounds.southEast);
+          pos2 = pos2.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
+
+          overlayImageOpt.offsets.add(new Offset(pos1.x.toDouble(), pos1.y.toDouble()));
+          overlayImageOpt.offsets.add(new Offset(pos2.x.toDouble(), pos2.y.toDouble()));
+          _loadImage(overlayImageOpt.imageProvider).then((image){
+            overlayImageOpt.image = image;
+          });
+        }
+
+        var overlayImages = <Widget>[];
+        for (var overlayImageOpt in this.overlayImageOpts.overlayImages) {
+          overlayImages.add(
+            new CustomPaint(
+              painter: new OverlayImagePainter(overlayImageOpt),
+              size: size,
+            ),
+          );
+        }
+
+        return new Container(
+          child: new Stack(
+            children: overlayImages,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class OverlayImagePainter extends CustomPainter {
+  final OverlayImage overlayImageOpt;
+  BoxFit boxfit = BoxFit.fitWidth;
+  OverlayImagePainter(this.overlayImageOpt);
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    canvas.clipRect(rect);
+    final paint = new Paint()
+    ..color = Color.fromRGBO(255, 255, 255, overlayImageOpt.opacity);
+    //..blendMode = BlendMode.modulate;
+    
+
+    final Size imageSize = new Size(overlayImageOpt.image.width.toDouble(), overlayImageOpt.image.height.toDouble());
+    final Rect inputSubrect = Offset.zero & imageSize;
+
+    canvas.drawImageRect(overlayImageOpt.image, inputSubrect, Rect.fromPoints(overlayImageOpt.offsets[0], overlayImageOpt.offsets[1]), paint);
+  }
+
+
+  @override
+  bool shouldRepaint(OverlayImagePainter other) => false;
+}
+
+double _dist(Offset v, Offset w) {
+  return sqrt(_dist2(v, w));
+}
+
+double _dist2(Offset v, Offset w) {
+  return _sqr(v.dx - w.dx) + _sqr(v.dy - w.dy);
+}
+
+double _sqr(double x) {
+  return x * x;
+}

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:flutter_map/src/gestures/gestures.dart';
 import 'package:flutter_map/src/layer/group_layer.dart';
+import 'package:flutter_map/src/layer/overlay_image_layer.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:positioned_tap_detector/positioned_tap_detector.dart';
 import 'package:async/async.dart';
@@ -90,6 +91,9 @@ class FlutterMapState extends MapGestureMixin {
     }
     if (options is GroupLayerOptions) {
       return new GroupLayer(options, mapState, _merge(options));
+    }
+    if (options is OverlayImageLayerOptions) {
+      return new OverlayImageLayer(options, mapState, _merge(options));
     }
     for (var plugin in plugins) {
       if (plugin.supportsLayer(options)) {


### PR DESCRIPTION
CircleMarker example:
```dart
new CircleMarker(
        point: new LatLng(51.5, -0.09),
        color: Colors.blue.withOpacity(0.7),
        useRadiusInMeter: true,
        radius: 2000// 2000 meters | 2 km
      )
```
Overlay image example:

```dart
new OverlayImage(
        bounds: LatLngBounds(LatLng(51.5, -0.09),LatLng(48.8566, 2.3522)),
        opacity: 0.8,
        imageProvider: NetworkImage('https://images.pexels.com/photos/231009/pexels-photo-231009.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=300&w=600')
      )
```
All modifications with full examples