### PR TITLE
make sw and ne private

### DIFF
--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -2,8 +2,8 @@ import 'dart:math' as math;
 import 'package:latlong/latlong.dart';
 
 class LatLngBounds {
-  LatLng sw;
-  LatLng ne;
+  LatLng _sw;
+  LatLng _ne;
   LatLngBounds([LatLng corner1, LatLng corner2]) {
     extend(corner1);
     extend(corner2);
@@ -17,18 +17,18 @@ class LatLngBounds {
   }
 
   void extendBounds(LatLngBounds bounds) {
-    _extend(bounds.sw, bounds.ne);
+    _extend(bounds._sw, bounds._ne);
   }
 
   void _extend(LatLng sw2, LatLng ne2) {
-    if (sw == null && ne == null) {
-      sw = new LatLng(sw2.latitude, sw2.longitude);
-      ne = new LatLng(ne2.latitude, ne2.longitude);
+    if (_sw == null && _ne == null) {
+      _sw = new LatLng(sw2.latitude, sw2.longitude);
+      _ne = new LatLng(ne2.latitude, ne2.longitude);
     } else {
-      sw.latitude = math.min(sw2.latitude, sw.latitude);
-      sw.longitude = math.min(sw2.longitude, sw.longitude);
-      ne.latitude = math.max(ne2.latitude, ne.latitude);
-      ne.longitude = math.max(ne2.longitude, ne.longitude);
+      _sw.latitude = math.min(sw2.latitude, _sw.latitude);
+      _sw.longitude = math.min(sw2.longitude, _sw.longitude);
+      _ne.latitude = math.max(ne2.latitude, _ne.latitude);
+      _ne.longitude = math.max(ne2.longitude, _ne.longitude);
     }
   }
 
@@ -37,13 +37,13 @@ class LatLngBounds {
   double get east => northEast.longitude;
   double get north => northEast.latitude;
 
-  LatLng get southWest => sw;
-  LatLng get northEast => ne;
+  LatLng get southWest => _sw;
+  LatLng get northEast => _ne;
   LatLng get northWest => new LatLng(north, west);
   LatLng get southEast => new LatLng(south, east);
 
   bool get isValid {
-    return sw != null && ne != null;
+    return _sw != null && _ne != null;
   }
 
   bool contains(LatLng point) {
@@ -53,11 +53,11 @@ class LatLngBounds {
   }
 
   bool containsBounds(LatLngBounds bounds) {
-    var sw2 = bounds.sw;
-    var ne2 = bounds.ne;
-    return (sw2.latitude >= sw.latitude) &&
-        (ne2.latitude <= ne.latitude) &&
-        (sw2.longitude >= sw.longitude) &&
-        (ne2.longitude <= ne.longitude);
+    var sw2 = bounds._sw;
+    var ne2 = bounds._ne;
+    return (sw2.latitude >= _sw.latitude) &&
+        (ne2.latitude <= _ne.latitude) &&
+        (sw2.longitude >= _sw.longitude) &&
+        (ne2.longitude <= _ne.longitude);
   }
 }


### PR DESCRIPTION
It is unnecessary to both expose the variables (`sw` and `ne`) and have separate getters (`southWest` and `northEast`) for them. It might even be confusing since someone might wonder what the difference between them is. Therefore I suggest that we make the variables sw and ne private.