### PR TITLE
Update gradle wrapper

### DIFF
--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
### Why this PR?

Executing `flutter run` in the example folder, with a running Pixel API 28 emulator, causes the following error:

```
* What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin [id 'com.android.application']
   > Minimum supported Gradle version is 4.6. Current version is 3.3. If using the gradle wrapper, try editing the distributionUrl in
   flutter_map/example/android/gradle/wrapper/gradle-wrapper.properties to gradle-4.6-all.zip
```

### How this PR fixes the issue?

Updated the distributionUrl to gradle-4.6-all.zip

### What are the expected outcomes after the merge?

It is possible to run the example app in the Android emulator.
