### PR TITLE
Fixes null pointer in isOutOfBounds

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -108,7 +108,9 @@ class MapOptions {
   //if there is a pan boundary, do not cross
   bool isOutOfBounds(LatLng center) {
     if (swPanBoundary != null && nePanBoundary != null) {
-      if (center.latitude < swPanBoundary.latitude ||
+      if (center == null) {
+        return true;
+      } else if (center.latitude < swPanBoundary.latitude ||
           center.latitude > nePanBoundary.latitude) {
         return true;
       } else if (center.longitude < swPanBoundary.longitude ||


### PR DESCRIPTION
This happens if you zoom out & pan too much. I am not sure if this should be fixed somewhere else so that center is never null but this is a quick fix for this particular place.

```
I/flutter (10829): ══╡ EXCEPTION CAUGHT BY GESTURE ╞═══════════════════════════════════════════════════════════════════
I/flutter (10829): The following NoSuchMethodError was thrown while handling a gesture:
I/flutter (10829): The getter 'latitude' was called on null.
I/flutter (10829): Receiver: null
I/flutter (10829): Tried calling: latitude
I/flutter (10829): 
I/flutter (10829): When the exception was thrown, this was the stack:
I/flutter (10829): #0      Object.noSuchMethod (dart:core/runtime/libobject_patch.dart:50:5)
I/flutter (10829): #1      MapOptions.isOutOfBounds (package:flutter_map/flutter_map.dart:111:18)
I/flutter (10829): #2      MapState.move (package:flutter_map/src/map/map.dart:100:30)
I/flutter (10829): #3      MapGestureMixin.handleScaleUpdate.<anonymous closure> (package:flutter_map/src/gestures/gestures.dart:64:11)
I/flutter (10829): #4      State.setState (package:flutter/src/widgets/framework.dart:1122:30)
I/flutter (10829): #5      MapGestureMixin.handleScaleUpdate (package:flutter_map/src/gestures/gestures.dart:58:5)
I/flutter (10829): #6      ScaleGestureRecognizer._advanceStateMachine.<anonymous closure> (package:flutter/src/gestures/scale.dart:391:9)
I/flutter (10829): #7      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:120:24)
I/flutter (10829): #8      ScaleGestureRecognizer._advanceStateMachine (package:flutter/src/gestures/scale.dart:390:7)
I/flutter (10829): #9      ScaleGestureRecognizer.handleEvent (package:flutter/src/gestures/scale.dart:285:7)
I/flutter (10829): #10     PointerRouter._dispatch (package:flutter/src/gestures/pointer_router.dart:73:12)
I/flutter (10829): #11     PointerRouter.route (package:flutter/src/gestures/pointer_router.dart:101:11)
I/flutter (10829): #12     _WidgetsFlutterBinding&BindingBase&GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:214:19)
I/flutter (10829): #13     _WidgetsFlutterBinding&BindingBase&GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:192:22)
I/flutter (10829): #14     _WidgetsFlutterBinding&BindingBase&GestureBinding._handlePointerEvent (package:flutter/src/gestures/binding.dart:149:7)
I/flutter (10829): #15     _WidgetsFlutterBinding&BindingBase&GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:101:7)
I/flutter (10829): #16     _WidgetsFlutterBinding&BindingBase&GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:85:7)
I/flutter (10829): #20     _invoke1 (dart:ui/hooks.dart:223:10)
I/flutter (10829): #21     _dispatchPointerDataPacket (dart:ui/hooks.dart:144:5)
I/flutter (10829): (elided 3 frames from package dart:async)
```