### PR TITLE
fix(EsriPage): drawer route string

### DIFF
--- a/example/lib/pages/esri.dart
+++ b/example/lib/pages/esri.dart
@@ -12,7 +12,7 @@ class EsriPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Esri')),
-      drawer: buildDrawer(context, TapToAddPage.route),
+      drawer: buildDrawer(context, route),
       body: Padding(
         padding: EdgeInsets.all(8.0),
         child: Column(


### PR DESCRIPTION
The esri page used the add pins page route name. This resulted in the add pins route being marked as active in the drawer.