### PR TITLE
Updates for incompatibilities with latest changes to flutter error handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.6.0] - 5/28/2019
+- Updated to support new error message formats. 
+- Updated flutter sdk dependency to v1.5.9
+
 ## [0.5.3] - 5/21/2019
 - update dependencies (#288)
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,3 @@
-include: package:pedantic/analysis_options.yaml
-
 linter:
   rules:
     - always_declare_return_types

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,8 +32,7 @@ class MyApp extends StatelessWidget {
         EsriPage.route: (context) => EsriPage(),
         PolylinePage.route: (context) => PolylinePage(),
         MapControllerPage.route: (context) => MapControllerPage(),
-        AnimatedMapControllerPage.route: (context) =>
-            AnimatedMapControllerPage(),
+        AnimatedMapControllerPage.route: (context) => AnimatedMapControllerPage(),
         MarkerAnchorPage.route: (context) => MarkerAnchorPage(),
         PluginPage.route: (context) => PluginPage(),
         OfflineMapPage.route: (context) => OfflineMapPage(),

--- a/example/lib/pages/animated_map_controller.dart
+++ b/example/lib/pages/animated_map_controller.dart
@@ -13,8 +13,7 @@ class AnimatedMapControllerPage extends StatefulWidget {
   }
 }
 
-class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage>
-    with TickerProviderStateMixin {
+class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage> with TickerProviderStateMixin {
   // Note the addition of the TickerProviderStateMixin here. If you are getting an error like
   // 'The class 'TickerProviderStateMixin' can't be used as a mixin because it extends a class other than Object.'
   // in your IDE, you can probably fix it by adding an analysis_options.yaml file to your project
@@ -40,24 +39,19 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage>
   void _animatedMapMove(LatLng destLocation, double destZoom) {
     // Create some tweens. These serve to split up the transition from one location to another.
     // In our case, we want to split the transition be<tween> our current map center and the destination.
-    final _latTween = Tween<double>(
-        begin: mapController.center.latitude, end: destLocation.latitude);
-    final _lngTween = Tween<double>(
-        begin: mapController.center.longitude, end: destLocation.longitude);
+    final _latTween = Tween<double>(begin: mapController.center.latitude, end: destLocation.latitude);
+    final _lngTween = Tween<double>(begin: mapController.center.longitude, end: destLocation.longitude);
     final _zoomTween = Tween<double>(begin: mapController.zoom, end: destZoom);
 
     // Create a animation controller that has a duration and a TickerProvider.
-    var controller = AnimationController(
-        duration: const Duration(milliseconds: 500), vsync: this);
+    var controller = AnimationController(duration: const Duration(milliseconds: 500), vsync: this);
     // The animation determines what path the animation will take. You can try different Curves values, although I found
     // fastOutSlowIn to be my favorite.
-    Animation<double> animation =
-        CurvedAnimation(parent: controller, curve: Curves.fastOutSlowIn);
+    Animation<double> animation = CurvedAnimation(parent: controller, curve: Curves.fastOutSlowIn);
 
     controller.addListener(() {
       mapController.move(
-          LatLng(_latTween.evaluate(animation), _lngTween.evaluate(animation)),
-          _zoomTween.evaluate(animation));
+          LatLng(_latTween.evaluate(animation), _lngTween.evaluate(animation)), _zoomTween.evaluate(animation));
     });
 
     animation.addStatusListener((status) {
@@ -163,16 +157,12 @@ class AnimatedMapControllerPageState extends State<AnimatedMapControllerPage>
             Flexible(
               child: FlutterMap(
                 mapController: mapController,
-                options: MapOptions(
-                    center: LatLng(51.5, -0.09),
-                    zoom: 5.0,
-                    maxZoom: 10.0,
-                    minZoom: 3.0),
+                options: MapOptions(center: LatLng(51.5, -0.09), zoom: 5.0, maxZoom: 10.0, minZoom: 3.0),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   MarkerLayerOptions(markers: markers)
                 ],
               ),

--- a/example/lib/pages/circle.dart
+++ b/example/lib/pages/circle.dart
@@ -37,9 +37,9 @@ class CirclePage extends StatelessWidget {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   CircleLayerOptions(circles: circleMarkers)
                 ],
               ),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -57,9 +57,9 @@ class HomePage extends StatelessWidget {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   MarkerLayerOptions(markers: markers)
                 ],
               ),

--- a/example/lib/pages/map_controller.dart
+++ b/example/lib/pages/map_controller.dart
@@ -121,10 +121,10 @@ class MapControllerPageState extends State<MapControllerPage> {
                       _scaffoldKey.currentState.showSnackBar(SnackBar(
                         content: Text(
                           'Map bounds: \n'
-                              'E: ${bounds.east} \n'
-                              'N: ${bounds.north} \n'
-                              'W: ${bounds.west} \n'
-                              'S: ${bounds.south}',
+                          'E: ${bounds.east} \n'
+                          'N: ${bounds.north} \n'
+                          'W: ${bounds.west} \n'
+                          'S: ${bounds.south}',
                         ),
                       ));
                     },
@@ -143,9 +143,9 @@ class MapControllerPageState extends State<MapControllerPage> {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   MarkerLayerOptions(markers: markers)
                 ],
               ),

--- a/example/lib/pages/marker_anchor.dart
+++ b/example/lib/pages/marker_anchor.dart
@@ -6,6 +6,7 @@ import '../widgets/drawer.dart';
 
 class MarkerAnchorPage extends StatefulWidget {
   static const String route = '/marker_anchors';
+
   @override
   MarkerAnchorPageState createState() {
     return MarkerAnchorPageState();
@@ -76,8 +77,7 @@ class MarkerAnchorPageState extends State<MarkerAnchorPage> {
           children: [
             Padding(
               padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: Text(
-                  'Markers can be anchored to the top, bottom, left or right.'),
+              child: Text('Markers can be anchored to the top, bottom, left or right.'),
             ),
             Padding(
               padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
@@ -125,9 +125,9 @@ class MarkerAnchorPageState extends State<MarkerAnchorPage> {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   MarkerLayerOptions(markers: markers)
                 ],
               ),

--- a/example/lib/pages/moving_markers.dart
+++ b/example/lib/pages/moving_markers.dart
@@ -59,9 +59,7 @@ class _MovingMarkersPageState extends State<MovingMarkersPage> {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                      urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', subdomains: ['a', 'b', 'c']),
                   MarkerLayerOptions(markers: <Marker>[_marker])
                 ],
               ),

--- a/example/lib/pages/offline_map.dart
+++ b/example/lib/pages/offline_map.dart
@@ -18,8 +18,7 @@ class OfflineMapPage extends StatelessWidget {
           children: [
             Padding(
               padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: Text(
-                  'This is an offline map that is showing Anholt Island, Denmark.'),
+              child: Text('This is an offline map that is showing Anholt Island, Denmark.'),
             ),
             Flexible(
               child: FlutterMap(
@@ -32,7 +31,7 @@ class OfflineMapPage extends StatelessWidget {
                   nePanBoundary: LatLng(56.7378, 11.6644),
                 ),
                 layers: [
-                  new TileLayerOptions(
+                  TileLayerOptions(
                     tileProvider: AssetTileProvider(),
                     maxZoom: 14.0,
                     urlTemplate: 'assets/map/anholt_osmbright/{z}/{x}/{y}.png',

--- a/example/lib/pages/offline_mbtiles_map.dart
+++ b/example/lib/pages/offline_mbtiles_map.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong/latlong.dart';
@@ -9,24 +7,25 @@ import '../widgets/drawer.dart';
 class OfflineMBTilesMapPage extends StatelessWidget {
   static const String route = '/offline_mbtiles_map';
 
+  @override
   Widget build(BuildContext context) {
-    return new Scaffold(
-      appBar: new AppBar(title: new Text("Offline Map (using MBTiles)")),
+    return Scaffold(
+      appBar: AppBar(title: Text('Offline Map (using MBTiles)')),
       drawer: buildDrawer(context, OfflineMBTilesMapPage.route),
-      body: new Padding(
-        padding: new EdgeInsets.all(8.0),
-        child: new Column(
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
           children: [
-            new Padding(
-              padding: new EdgeInsets.only(top: 8.0, bottom: 8.0),
-              child: new Text(
-                  "This is an offline map of Berlin, Germany using a single MBTiles file. The file was built from the Stamen toner map data (http://maps.stamen.com).\n\n"
-                  "(Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL.)"),
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text('This is an offline map of Berlin, Germany using a single MBTiles file. '
+                  'The file was built from the Stamen toner map data (http://maps.stamen.com).\n\n'
+                  '(Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL.)'),
             ),
-            new Flexible(
-              child: new FlutterMap(
-                options: new MapOptions(
-                  center: new LatLng(
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(
                     52.516144,
                     13.404938,
                   ),
@@ -37,12 +36,12 @@ class OfflineMBTilesMapPage extends StatelessWidget {
                   nePanBoundary: LatLng(52.540084, 13.527795),
                 ),
                 layers: [
-                  new TileLayerOptions(
-                      tileProvider: MBTilesImageProvider.fromAsset(
-                          "assets/berlin.mbtiles"),
-                      maxZoom: 14.0,
-                      backgroundColor: Colors.white,
-                      tms: true),
+                  TileLayerOptions(
+                    tileProvider: MBTilesImageProvider.fromAsset('assets/berlin.mbtiles'),
+                    maxZoom: 14.0,
+                    backgroundColor: Colors.white,
+                    tms: true,
+                  ),
                 ],
               ),
             ),

--- a/example/lib/pages/on_tap.dart
+++ b/example/lib/pages/on_tap.dart
@@ -90,9 +90,9 @@ class OnTapPageState extends State<OnTapPage> {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   MarkerLayerOptions(markers: markers)
                 ],
               ),

--- a/example/lib/pages/overlay_image.dart
+++ b/example/lib/pages/overlay_image.dart
@@ -36,9 +36,9 @@ class OverlayImagePage extends StatelessWidget {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   OverlayImageLayerOptions(overlayImages: overlayImages)
                 ],
               ),

--- a/example/lib/pages/plugin_api.dart
+++ b/example/lib/pages/plugin_api.dart
@@ -27,9 +27,9 @@ class PluginPage extends StatelessWidget {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   MyCustomPluginOptions(text: "I'm a plugin!"),
                 ],
               ),
@@ -43,13 +43,13 @@ class PluginPage extends StatelessWidget {
 
 class MyCustomPluginOptions extends LayerOptions {
   final String text;
+
   MyCustomPluginOptions({this.text = ''});
 }
 
 class MyCustomPlugin implements MapPlugin {
   @override
-  Widget createLayer(
-      LayerOptions options, MapState mapState, Stream<Null> stream) {
+  Widget createLayer(LayerOptions options, MapState mapState, Stream<void> stream) {
     if (options is MyCustomPluginOptions) {
       var style = TextStyle(
         fontWeight: FontWeight.bold,

--- a/example/lib/pages/polyline.dart
+++ b/example/lib/pages/polyline.dart
@@ -33,15 +33,12 @@ class PolylinePage extends StatelessWidget {
                 ),
                 layers: [
                   TileLayerOptions(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c']),
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
                   PolylineLayerOptions(
                     polylines: [
-                      Polyline(
-                          points: points,
-                          strokeWidth: 4.0,
-                          color: Colors.purple),
+                      Polyline(points: points, strokeWidth: 4.0, color: Colors.purple),
                     ],
                   )
                 ],

--- a/example/lib/pages/tap_to_add.dart
+++ b/example/lib/pages/tap_to_add.dart
@@ -42,14 +42,10 @@ class TapToAddPageState extends State<TapToAddPage> {
             ),
             Flexible(
               child: FlutterMap(
-                options: MapOptions(
-                    center: LatLng(45.5231, -122.6765),
-                    zoom: 13.0,
-                    onTap: _handleTap),
+                options: MapOptions(center: LatLng(45.5231, -122.6765), zoom: 13.0, onTap: _handleTap),
                 layers: [
                   TileLayerOptions(
-                    urlTemplate:
-                        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   ),
                   MarkerLayerOptions(markers: markers)
                 ],

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -63,8 +63,7 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           title: const Text('Animated MapController'),
           selected: currentRoute == AnimatedMapControllerPage.route,
           onTap: () {
-            Navigator.pushReplacementNamed(
-                context, AnimatedMapControllerPage.route);
+            Navigator.pushReplacementNamed(context, AnimatedMapControllerPage.route);
           },
         ),
         ListTile(
@@ -92,8 +91,7 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           title: const Text('Offline Map (using MBTiles)'),
           selected: currentRoute == OfflineMBTilesMapPage.route,
           onTap: () {
-            Navigator.pushReplacementNamed(
-                context, OfflineMBTilesMapPage.route);
+            Navigator.pushReplacementNamed(context, OfflineMBTilesMapPage.route);
           },
         ),
         ListTile(

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -12,13 +12,14 @@ import 'package:flutter_map/src/plugins/plugin.dart';
 import 'package:latlong/latlong.dart';
 
 export 'package:flutter_map/src/core/point.dart';
+
 export 'src/geo/crs/crs.dart';
 export 'src/geo/latlng_bounds.dart';
-export 'src/layer/mbtiles/mbtiles_image_provider.dart';
 export 'src/layer/circle_layer.dart';
 export 'src/layer/group_layer.dart';
 export 'src/layer/layer.dart';
 export 'src/layer/marker_layer.dart';
+export 'src/layer/mbtiles/mbtiles_image_provider.dart';
 export 'src/layer/overlay_image_layer.dart';
 export 'src/layer/polygon_layer.dart';
 export 'src/layer/polyline_layer.dart';
@@ -55,14 +56,20 @@ class FlutterMap extends StatefulWidget {
 abstract class MapController {
   /// Moves the map to a specific location and zoom level
   void move(LatLng center, double zoom);
+
   void fitBounds(
     LatLngBounds bounds, {
     FitBoundsOptions options,
   });
+
   bool get ready;
-  Future<Null> get onReady;
+
+  Future<void> get onReady;
+
   LatLng get center;
+
   LatLngBounds get bounds;
+
   double get zoom;
 
   factory MapController() => MapControllerImpl();
@@ -111,11 +118,9 @@ class MapOptions {
     if (swPanBoundary != null && nePanBoundary != null) {
       if (center == null) {
         return true;
-      } else if (center.latitude < swPanBoundary.latitude ||
-          center.latitude > nePanBoundary.latitude) {
+      } else if (center.latitude < swPanBoundary.latitude || center.latitude > nePanBoundary.latitude) {
         return true;
-      } else if (center.longitude < swPanBoundary.longitude ||
-          center.longitude > nePanBoundary.longitude) {
+      } else if (center.longitude < swPanBoundary.longitude || center.longitude > nePanBoundary.longitude) {
         return true;
       }
     }
@@ -140,5 +145,6 @@ class MapPosition {
   final LatLngBounds bounds;
   final double zoom;
   final bool hasGesture;
+
   MapPosition({this.center, this.bounds, this.zoom, this.hasGesture = false});
 }

--- a/lib/src/core/bounds.dart
+++ b/lib/src/core/bounds.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+
 import 'point.dart';
 
 class Bounds<T extends num> {
@@ -38,8 +39,11 @@ class Bounds<T extends num> {
   }
 
   CustomPoint<T> get bottomLeft => CustomPoint(min.x, max.y);
+
   CustomPoint<T> get topRight => CustomPoint(max.x, min.y);
+
   CustomPoint<T> get topLeft => min;
+
   CustomPoint<T> get bottomRight => max;
 
   CustomPoint<T> get size {
@@ -53,10 +57,7 @@ class Bounds<T extends num> {
   }
 
   bool containsBounds(Bounds<T> b) {
-    return (b.min.x >= min.x) &&
-        (b.max.x <= max.x) &&
-        (b.min.y >= min.y) &&
-        (b.max.y <= max.y);
+    return (b.min.x >= min.x) && (b.max.x <= max.x) && (b.min.y >= min.y) && (b.max.y <= max.y);
   }
 
   @override

--- a/lib/src/core/center_zoom.dart
+++ b/lib/src/core/center_zoom.dart
@@ -3,5 +3,6 @@ import 'package:latlong/latlong.dart';
 class CenterZoom {
   final LatLng center;
   final double zoom;
+
   CenterZoom({this.center, this.zoom});
 }

--- a/lib/src/core/point.dart
+++ b/lib/src/core/point.dart
@@ -45,7 +45,7 @@ class CustomPoint<T extends num> extends math.Point<T> {
   }
 
   CustomPoint multiplyBy(num n) {
-      return CustomPoint(x * n, y * n);
+    return CustomPoint(x * n, y * n);
   }
 
   @override

--- a/lib/src/core/util.dart
+++ b/lib/src/core/util.dart
@@ -1,6 +1,7 @@
 import 'package:tuple/tuple.dart';
 
 var _templateRe = RegExp(r'\{ *([\w_-]+) *\}');
+
 String template(String str, Map<String, String> data) {
   return str.replaceAllMapped(_templateRe, (Match match) {
     var value = data[match.group(1)];

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -1,14 +1,15 @@
 import 'dart:math' as math;
 
-import 'package:tuple/tuple.dart';
-import 'package:latlong/latlong.dart';
 import 'package:flutter_map/src/core/bounds.dart';
-
 import 'package:flutter_map/src/core/point.dart';
+import 'package:latlong/latlong.dart';
+import 'package:tuple/tuple.dart';
 
 abstract class Crs {
   String get code;
+
   Projection get projection;
+
   Transformation get transformation;
 
   const Crs();
@@ -52,7 +53,9 @@ abstract class Crs {
   }
 
   bool get infinite;
+
   Tuple2<double, double> get wrapLng;
+
   Tuple2<double, double> get wrapLat;
 }
 
@@ -91,7 +94,9 @@ abstract class Projection {
   const Projection();
 
   Bounds<double> get bounds;
+
   CustomPoint project(LatLng latlng);
+
   LatLng unproject(CustomPoint point);
 }
 
@@ -116,16 +121,13 @@ class SphericalMercator extends Projection {
     var lat = math.max(math.min(max, latlng.latitude), -max);
     var sin = math.sin(lat * d);
 
-    return CustomPoint(
-        r * latlng.longitude * d, r * math.log((1 + sin) / (1 - sin)) / 2);
+    return CustomPoint(r * latlng.longitude * d, r * math.log((1 + sin) / (1 - sin)) / 2);
   }
 
   @override
   LatLng unproject(CustomPoint point) {
     var d = 180 / math.pi;
-    return LatLng(
-        (2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d,
-        point.x * d / r);
+    return LatLng((2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d, point.x * d / r);
   }
 }
 
@@ -134,6 +136,7 @@ class Transformation {
   final num b;
   final num c;
   final num d;
+
   const Transformation(this.a, this.b, this.c, this.d);
 
   CustomPoint transform(CustomPoint<num> point, double scale) {

--- a/lib/src/geo/latlng_bounds.dart
+++ b/lib/src/geo/latlng_bounds.dart
@@ -1,9 +1,11 @@
 import 'dart:math' as math;
+
 import 'package:latlong/latlong.dart';
 
 class LatLngBounds {
   LatLng _sw;
   LatLng _ne;
+
   LatLngBounds([LatLng corner1, LatLng corner2]) {
     extend(corner1);
     extend(corner2);
@@ -33,13 +35,19 @@ class LatLngBounds {
   }
 
   double get west => southWest.longitude;
+
   double get south => southWest.latitude;
+
   double get east => northEast.longitude;
+
   double get north => northEast.latitude;
 
   LatLng get southWest => _sw;
+
   LatLng get northEast => _ne;
+
   LatLng get northWest => LatLng(north, west);
+
   LatLng get southEast => LatLng(south, east);
 
   bool get isValid {

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -7,8 +7,7 @@ import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong/latlong.dart';
 import 'package:positioned_tap_detector/positioned_tap_detector.dart';
 
-abstract class MapGestureMixin extends State<FlutterMap>
-    with TickerProviderStateMixin {
+abstract class MapGestureMixin extends State<FlutterMap> with TickerProviderStateMixin {
   static const double _kMinFlingVelocity = 800.0;
 
   LatLng _mapCenterStart;
@@ -26,18 +25,19 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
   @override
   FlutterMap get widget;
+
   MapState get mapState;
+
   MapState get map => mapState;
+
   MapOptions get options;
 
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(vsync: this)
-      ..addListener(_handleFlingAnimation);
-    _doubleTapController =
-        AnimationController(vsync: this, duration: Duration(milliseconds: 200))
-          ..addListener(_handleDoubleTapZoomAnimation);
+    _controller = AnimationController(vsync: this)..addListener(_handleFlingAnimation);
+    _doubleTapController = AnimationController(vsync: this, duration: Duration(milliseconds: 200))
+      ..addListener(_handleDoubleTapZoomAnimation);
   }
 
   void handleScaleStart(ScaleStartDetails details) {
@@ -111,8 +111,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
     // convert the point to global coordinates
     var localPoint = _offsetToPoint(offset);
-    var localPointCenterDistance = CustomPoint(
-        (width / 2) - localPoint.x, (height / 2) - localPoint.y);
+    var localPointCenterDistance = CustomPoint((width / 2) - localPoint.x, (height / 2) - localPoint.y);
     var mapCenter = map.project(map.center);
     var point = mapCenter - localPointCenterDistance;
     return map.unproject(point);
@@ -121,24 +120,19 @@ abstract class MapGestureMixin extends State<FlutterMap>
   void handleDoubleTap(TapPosition tapPosition) {
     final centerPos = _pointToOffset(map.size) / 2.0;
     final newZoom = _getZoomForScale(map.zoom, 2.0);
-    final focalDelta = _getDoubleTapFocalDelta(
-        centerPos, tapPosition.relative, newZoom - map.zoom);
+    final focalDelta = _getDoubleTapFocalDelta(centerPos, tapPosition.relative, newZoom - map.zoom);
     final newCenter = _offsetToCrs(centerPos + focalDelta);
     _startDoubleTapAnimation(newZoom, newCenter);
   }
 
-  Offset _getDoubleTapFocalDelta(
-      Offset centerPos, Offset tapPos, double zoomDiff) {
+  Offset _getDoubleTapFocalDelta(Offset centerPos, Offset tapPos, double zoomDiff) {
     final tapDelta = tapPos - centerPos;
     final zoomScale = 1 / math.pow(2, zoomDiff);
     // map center offset within which double-tap won't
     // cause zooming to previously invisible area
     final maxDelta = centerPos * (1 - zoomScale);
-    final tappedOutExtent =
-        tapDelta.dx.abs() > maxDelta.dx || tapDelta.dy.abs() > maxDelta.dy;
-    return tappedOutExtent
-        ? _projectDeltaOnBounds(tapDelta, maxDelta)
-        : tapDelta;
+    final tappedOutExtent = tapDelta.dx.abs() > maxDelta.dx || tapDelta.dy.abs() > maxDelta.dy;
+    return tappedOutExtent ? _projectDeltaOnBounds(tapDelta, maxDelta) : tapDelta;
   }
 
   Offset _projectDeltaOnBounds(Offset delta, Offset maxDelta) {
@@ -173,8 +167,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
   void _handleFlingAnimation() {
     setState(() {
       _flingOffset = _flingAnimation.value;
-      var newCenterPoint = map.project(_mapCenterStart) +
-          CustomPoint(_flingOffset.dx, _flingOffset.dy);
+      var newCenterPoint = map.project(_mapCenterStart) + CustomPoint(_flingOffset.dx, _flingOffset.dy);
       var newCenter = map.unproject(newCenterPoint);
       map.move(newCenter, map.zoom, hasGesture: true, isUserGesture: true);
     });
@@ -188,11 +181,9 @@ abstract class MapGestureMixin extends State<FlutterMap>
     return Offset(point.x.toDouble(), point.y.toDouble());
   }
 
-  Offset get _mapOffset =>
-      (context.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
+  Offset get _mapOffset => (context.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
 
-  double _getZoomForScale(double startZoom, double scale) =>
-      startZoom + math.log(scale) / math.ln2;
+  double _getZoomForScale(double startZoom, double scale) => startZoom + math.log(scale) / math.ln2;
 
   @override
   void dispose() {

--- a/lib/src/gestures/latlng_tween.dart
+++ b/lib/src/gestures/latlng_tween.dart
@@ -3,8 +3,10 @@ import 'package:flutter/foundation.dart';
 import 'package:latlong/latlong.dart';
 
 class LatLngTween extends Tween<LatLng> {
-  LatLngTween({@required LatLng begin, @required LatLng end})
-      : super(begin: begin, end: end);
+  LatLngTween({
+    @required LatLng begin,
+    @required LatLng end,
+  }) : super(begin: begin, end: end);
 
   @override
   LatLng lerp(double t) => LatLng(

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -7,8 +7,11 @@ import 'package:latlong/latlong.dart' hide Path; // conflict with Path from UI
 
 class CircleLayerOptions extends LayerOptions {
   final List<CircleMarker> circles;
-  CircleLayerOptions({this.circles = const [], rebuild})
-      : super(rebuild: rebuild);
+
+  CircleLayerOptions({
+    this.circles = const [],
+    Stream<void> rebuild,
+  }) : super(rebuild: rebuild);
 }
 
 class CircleMarker {
@@ -34,7 +37,8 @@ class CircleMarker {
 class CircleLayer extends StatelessWidget {
   final CircleLayerOptions circleOpts;
   final MapState map;
-  final Stream<Null> stream;
+  final Stream<void> stream;
+
   CircleLayer(this.circleOpts, this.map, this.stream);
 
   @override

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -20,6 +20,7 @@ class CircleMarker {
   final bool useRadiusInMeter;
   Offset offset = Offset.zero;
   num realRadius = 0;
+
   CircleMarker({
     this.point,
     this.radius,
@@ -53,15 +54,13 @@ class CircleLayer extends StatelessWidget {
         var circleWidgets = <Widget>[];
         for (var circle in circleOpts.circles) {
           var pos = map.project(circle.point);
-          pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
-              map.getPixelOrigin();
+          pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
           circle.offset = Offset(pos.x.toDouble(), pos.y.toDouble());
 
           if (circle.useRadiusInMeter) {
             var r = Distance().offset(circle.point, circle.radius, 180);
             var rpos = map.project(r);
-            rpos = rpos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
-                map.getPixelOrigin();
+            rpos = rpos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
 
             circle.realRadius = rpos.y - pos.y;
           }
@@ -86,6 +85,7 @@ class CircleLayer extends StatelessWidget {
 
 class CirclePainter extends CustomPainter {
   final CircleMarker circle;
+
   CirclePainter(this.circle);
 
   @override
@@ -96,8 +96,7 @@ class CirclePainter extends CustomPainter {
       ..style = PaintingStyle.fill
       ..color = circle.color;
 
-    _paintCircle(canvas, circle.offset,
-        circle.useRadiusInMeter ? circle.realRadius : circle.radius, paint);
+    _paintCircle(canvas, circle.offset, circle.useRadiusInMeter ? circle.realRadius : circle.radius, paint);
   }
 
   void _paintCircle(Canvas canvas, Offset offset, double radius, Paint paint) {

--- a/lib/src/layer/group_layer.dart
+++ b/lib/src/layer/group_layer.dart
@@ -11,7 +11,7 @@ class GroupLayerOptions extends LayerOptions {
 class GroupLayer extends StatelessWidget {
   final GroupLayerOptions groupOpts;
   final MapState map;
-  final Stream<Null> stream;
+  final Stream<void> stream;
 
   GroupLayer(this.groupOpts, this.map, this.stream);
 

--- a/lib/src/layer/layer.dart
+++ b/lib/src/layer/layer.dart
@@ -1,4 +1,5 @@
 class LayerOptions {
-  Stream<Null> rebuild;
+  Stream<void> rebuild;
+
   LayerOptions({this.rebuild});
 }

--- a/lib/src/layer/layer.dart
+++ b/lib/src/layer/layer.dart
@@ -2,4 +2,3 @@ class LayerOptions {
   Stream<Null> rebuild;
   LayerOptions({this.rebuild});
 }
-

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -101,9 +101,9 @@ class MarkerLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<int>(
-      stream: stream, // a Stream<int> or null
-      builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+    return StreamBuilder<void>(
+      stream: stream, // a Stream<void> or null
+      builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
         var markers = <Widget>[];
         for (var markerOpt in markerOpts.markers) {
           var pos = map.project(markerOpt.point);

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -57,8 +57,11 @@ class Anchor {
 
 class AnchorPos<T> {
   AnchorPos._(this.value);
+
   T value;
+
   static AnchorPos exactly(Anchor anchor) => AnchorPos._(anchor);
+
   static AnchorPos align(AnchorAlign alignOpt) => AnchorPos._(alignOpt);
 }
 
@@ -101,13 +104,10 @@ class MarkerLayer extends StatelessWidget {
         var markers = <Widget>[];
         for (var markerOpt in markerOpts.markers) {
           var pos = map.project(markerOpt.point);
-          pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
-              map.getPixelOrigin();
+          pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
 
-          var pixelPosX =
-              (pos.x - (markerOpt.width - markerOpt.anchor.left)).toDouble();
-          var pixelPosY =
-              (pos.y - (markerOpt.height - markerOpt.anchor.top)).toDouble();
+          var pixelPosX = (pos.x - (markerOpt.width - markerOpt.anchor.left)).toDouble();
+          var pixelPosY = (pos.y - (markerOpt.height - markerOpt.anchor.top)).toDouble();
 
           if (!map.bounds.contains(markerOpt.point)) {
             continue;

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -5,8 +5,11 @@ import 'package:latlong/latlong.dart';
 
 class MarkerLayerOptions extends LayerOptions {
   final List<Marker> markers;
-  MarkerLayerOptions({this.markers = const [], rebuild})
-      : super(rebuild: rebuild);
+
+  MarkerLayerOptions({
+    this.markers = const [],
+    Stream<void> rebuild,
+  }) : super(rebuild: rebuild);
 }
 
 class Anchor {
@@ -92,7 +95,7 @@ class Marker {
 class MarkerLayer extends StatelessWidget {
   final MarkerLayerOptions markerOpts;
   final MapState map;
-  final Stream<Null> stream;
+  final Stream<void> stream;
 
   MarkerLayer(this.markerOpts, this.map, this.stream);
 

--- a/lib/src/layer/mbtiles/mbtiles_image_provider.dart
+++ b/lib/src/layer/mbtiles/mbtiles_image_provider.dart
@@ -21,11 +21,9 @@ class MBTilesImageProvider extends TileProvider {
     database = _loadMBTilesDatabase();
   }
 
-  factory MBTilesImageProvider.fromAsset(String asset) =>
-      MBTilesImageProvider._(asset: asset);
+  factory MBTilesImageProvider.fromAsset(String asset) => MBTilesImageProvider._(asset: asset);
 
-  factory MBTilesImageProvider.fromFile(File mbtilesFile) =>
-      MBTilesImageProvider._(mbtilesFile: mbtilesFile);
+  factory MBTilesImageProvider.fromFile(File mbtilesFile) => MBTilesImageProvider._(mbtilesFile: mbtilesFile);
 
   Future<Database> _loadMBTilesDatabase() async {
     if (_loadedDb == null) {
@@ -54,22 +52,18 @@ class MBTilesImageProvider extends TileProvider {
 
   Future<File> copyFileFromAssets() async {
     var tempDir = await getTemporaryDirectory();
-    var filename = asset.split("/").last;
-    var file = File("${tempDir.path}/$filename");
+    var filename = asset.split('/').last;
+    var file = File('${tempDir.path}/$filename');
 
     var data = await rootBundle.load(asset);
-    file.writeAsBytesSync(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-        flush: true);
+    file.writeAsBytesSync(data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes), flush: true);
     return file;
   }
 
   @override
   ImageProvider getImage(Coords<num> coords, TileLayerOptions options) {
     var x = coords.x.round();
-    var y = options.tms
-        ? invertY(coords.y.round(), coords.z.round())
-        : coords.y.round();
+    var y = options.tms ? invertY(coords.y.round(), coords.z.round()) : coords.y.round();
     var z = coords.z.round();
 
     return MBTileImage(
@@ -100,18 +94,18 @@ class MBTileImage extends ImageProvider<MBTileImage> {
   Future<Codec> _loadAsync(MBTileImage key) async {
     assert(key == this);
 
-    final Database db = await key.database;
-    List<Map> result = await db.rawQuery("select tile_data from tiles "
-        "where zoom_level = ${coords.z} AND "
-        "tile_column = ${coords.x} AND "
-        "tile_row = ${coords.y} limit 1");
-    final Uint8List bytes =
-        result.length > 0 ? result.first["tile_data"] : null;
+    final db = await key.database;
+    List<Map> result = await db.rawQuery('select tile_data from tiles '
+        'where zoom_level = ${coords.z} AND '
+        'tile_column = ${coords.x} AND '
+        'tile_row = ${coords.y} limit 1');
+    final Uint8List bytes = result.isNotEmpty ? result.first['tile_data'] : null;
 
-    if (bytes == null)
-      return Future<Codec>.error("Failed to load tile for coords: $coords");
-    else
+    if (bytes == null) {
+      return Future<Codec>.error('Failed to load tile for coords: $coords');
+    } else {
       return await PaintingBinding.instance.instantiateImageCodec(bytes);
+    }
   }
 
   @override
@@ -124,6 +118,6 @@ class MBTileImage extends ImageProvider<MBTileImage> {
 
   @override
   bool operator ==(other) {
-    return other is MBTileImage && coords == other?.coords;
+    return other is MBTileImage && coords == other.coords;
   }
 }

--- a/lib/src/layer/mbtiles/mbtiles_image_provider.dart
+++ b/lib/src/layer/mbtiles/mbtiles_image_provider.dart
@@ -32,13 +32,12 @@ class MBTilesImageProvider extends TileProvider {
       _loadedDb = await openDatabase(file.path);
 
       if (isDisposed) {
-        _loadedDb.close();
+        await _loadedDb.close();
         _loadedDb = null;
-        throw new Exception("Tileprovider is already disposed");
+        throw Exception('Tileprovider is already disposed');
       }
-
-      return _loadedDb;
     }
+    return _loadedDb;
   }
 
   @override

--- a/lib/src/layer/mbtiles/mbtiles_image_provider.dart
+++ b/lib/src/layer/mbtiles/mbtiles_image_provider.dart
@@ -88,12 +88,13 @@ class MBTileImage extends ImageProvider<MBTileImage> {
   @override
   ImageStreamCompleter load(MBTileImage key) {
     return MultiFrameImageStreamCompleter(
-        codec: _loadAsync(key),
-        scale: 1,
-        informationCollector: (StringBuffer information) {
-          information.writeln('Image provider: $this');
-          information.write('Image key: $key');
-        });
+      codec: _loadAsync(key),
+      scale: 1,
+      informationCollector: () sync* {
+        yield DiagnosticsProperty<ImageProvider>('Image provider', this);
+        yield DiagnosticsProperty<ImageProvider>('Image key', key);
+      },
+    );
   }
 
   Future<Codec> _loadAsync(MBTileImage key) async {

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -36,12 +36,12 @@ class OverlayImage {
 Future<ui.Image> _loadImage(img.ImageProvider imageProvider) async {
   var stream = imageProvider.resolve(img.ImageConfiguration.empty);
   var completer = Completer<ui.Image>();
-  void listener(img.ImageInfo frame, bool synchronousCall) {
+  img.ImageStreamListener listener;
+  listener = img.ImageStreamListener((img.ImageInfo frame, bool synchronousCall) {
     var image = frame.image;
     completer.complete(image);
     stream.removeListener(listener);
-  }
-
+  });
   stream.addListener(listener);
   return completer.future;
 }

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -2,11 +2,10 @@ import 'dart:async';
 import 'dart:ui';
 import 'dart:ui' as ui;
 
+import 'package:flutter/painting.dart' as img;
 import 'package:flutter/rendering.dart' as img;
 import 'package:flutter/services.dart' as img;
 import 'package:flutter/widgets.dart' as img;
-import 'package:flutter/painting.dart' as img;
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
@@ -68,16 +67,12 @@ class OverlayImageLayer extends StatelessWidget {
         for (var overlayImageOpt in overlayImageOpts.overlayImages) {
           overlayImageOpt.offsets.clear();
           var pos1 = map.project(overlayImageOpt.bounds.northWest);
-          pos1 = pos1.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
-              map.getPixelOrigin();
+          pos1 = pos1.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
           var pos2 = map.project(overlayImageOpt.bounds.southEast);
-          pos2 = pos2.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
-              map.getPixelOrigin();
+          pos2 = pos2.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
 
-          overlayImageOpt.offsets
-              .add(Offset(pos1.x.toDouble(), pos1.y.toDouble()));
-          overlayImageOpt.offsets
-              .add(Offset(pos2.x.toDouble(), pos2.y.toDouble()));
+          overlayImageOpt.offsets.add(Offset(pos1.x.toDouble(), pos1.y.toDouble()));
+          overlayImageOpt.offsets.add(Offset(pos2.x.toDouble(), pos2.y.toDouble()));
           _loadImage(overlayImageOpt.imageProvider).then((image) {
             overlayImageOpt.image = image;
           });
@@ -106,23 +101,20 @@ class OverlayImageLayer extends StatelessWidget {
 class OverlayImagePainter extends CustomPainter {
   final OverlayImage overlayImageOpt;
   BoxFit boxfit = BoxFit.fitWidth;
+
   OverlayImagePainter(this.overlayImageOpt);
+
   @override
   void paint(Canvas canvas, Size size) {
     var rect = Offset.zero & size;
     canvas.clipRect(rect);
-    var paint = Paint()
-      ..color = Color.fromRGBO(255, 255, 255, overlayImageOpt.opacity);
+    var paint = Paint()..color = Color.fromRGBO(255, 255, 255, overlayImageOpt.opacity);
 
-    var imageSize = Size(overlayImageOpt.image.width.toDouble(),
-        overlayImageOpt.image.height.toDouble());
+    var imageSize = Size(overlayImageOpt.image.width.toDouble(), overlayImageOpt.image.height.toDouble());
     var inputSubrect = Offset.zero & imageSize;
 
-    canvas.drawImageRect(
-        overlayImageOpt.image,
-        inputSubrect,
-        Rect.fromPoints(overlayImageOpt.offsets[0], overlayImageOpt.offsets[1]),
-        paint);
+    canvas.drawImageRect(overlayImageOpt.image, inputSubrect,
+        Rect.fromPoints(overlayImageOpt.offsets[0], overlayImageOpt.offsets[1]), paint);
   }
 
   @override

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -12,8 +12,11 @@ import 'package:flutter_map/src/map/map.dart';
 
 class OverlayImageLayerOptions extends LayerOptions {
   final List<OverlayImage> overlayImages;
-  OverlayImageLayerOptions({this.overlayImages = const [], rebuild})
-      : super(rebuild: rebuild);
+
+  OverlayImageLayerOptions({
+    this.overlayImages = const [],
+    Stream<void> rebuild,
+  }) : super(rebuild: rebuild);
 }
 
 class OverlayImage {
@@ -46,7 +49,7 @@ Future<ui.Image> _loadImage(img.ImageProvider imageProvider) async {
 class OverlayImageLayer extends StatelessWidget {
   final OverlayImageLayerOptions overlayImageOpts;
   final MapState map;
-  final Stream<Null> stream;
+  final Stream<void> stream;
 
   OverlayImageLayer(this.overlayImageOpts, this.map, this.stream);
 

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -3,7 +3,7 @@ import 'dart:ui';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/map/map.dart';
-import 'package:latlong/latlong.dart' hide Path;  // conflict with Path from UI
+import 'package:latlong/latlong.dart' hide Path; // conflict with Path from UI
 
 class PolygonLayerOptions extends LayerOptions {
   final List<Polygon> polygons;
@@ -17,6 +17,7 @@ class Polygon {
   final Color color;
   final double borderStrokeWidth;
   final Color borderColor;
+
   Polygon({
     this.points,
     this.color = const Color(0xFF00FF00),
@@ -82,6 +83,7 @@ class PolygonLayer extends StatelessWidget {
 
 class PolygonPainter extends CustomPainter {
   final Polygon polygonOpt;
+
   PolygonPainter(this.polygonOpt);
 
   @override
@@ -96,15 +98,15 @@ class PolygonPainter extends CustomPainter {
       ..color = polygonOpt.color;
     final borderPaint = polygonOpt.borderStrokeWidth > 0.0
         ? (Paint()
-      ..color = polygonOpt.borderColor
-      ..strokeWidth = polygonOpt.borderStrokeWidth)
+          ..color = polygonOpt.borderColor
+          ..strokeWidth = polygonOpt.borderStrokeWidth)
         : null;
 
     _paintPolygon(canvas, polygonOpt.offsets, paint);
 
     var borderRadius = (polygonOpt.borderStrokeWidth / 2);
     if (polygonOpt.borderStrokeWidth > 0.0) {
-        _paintLine(canvas, polygonOpt.offsets, borderRadius, borderPaint);
+      _paintLine(canvas, polygonOpt.offsets, borderRadius, borderPaint);
     }
   }
 

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -7,8 +7,11 @@ import 'package:latlong/latlong.dart' hide Path; // conflict with Path from UI
 
 class PolygonLayerOptions extends LayerOptions {
   final List<Polygon> polygons;
-  PolygonLayerOptions({this.polygons = const [], rebuild})
-      : super(rebuild: rebuild);
+
+  PolygonLayerOptions({
+    this.polygons = const [],
+    Stream<void> rebuild,
+  }) : super(rebuild: rebuild);
 }
 
 class Polygon {
@@ -29,7 +32,7 @@ class Polygon {
 class PolygonLayer extends StatelessWidget {
   final PolygonLayerOptions polygonOpts;
   final MapState map;
-  final Stream<Null> stream;
+  final Stream<void> stream;
 
   PolygonLayer(this.polygonOpts, this.map, this.stream);
 

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -20,6 +20,7 @@ class Polyline {
   final double borderStrokeWidth;
   final Color borderColor;
   final bool isDotted;
+
   Polyline({
     this.points,
     this.strokeWidth = 1.0,
@@ -56,12 +57,10 @@ class PolylineLayer extends StatelessWidget {
           var i = 0;
           for (var point in polylineOpt.points) {
             var pos = map.project(point);
-            pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) -
-                map.getPixelOrigin();
+            pos = pos.multiplyBy(map.getZoomScale(map.zoom, map.zoom)) - map.getPixelOrigin();
             polylineOpt.offsets.add(Offset(pos.x.toDouble(), pos.y.toDouble()));
             if (i > 0 && i < polylineOpt.points.length) {
-              polylineOpt.offsets
-                  .add(Offset(pos.x.toDouble(), pos.y.toDouble()));
+              polylineOpt.offsets.add(Offset(pos.x.toDouble(), pos.y.toDouble()));
             }
             i++;
           }
@@ -89,6 +88,7 @@ class PolylineLayer extends StatelessWidget {
 
 class PolylinePainter extends CustomPainter {
   final Polyline polylineOpt;
+
   PolylinePainter(this.polylineOpt);
 
   @override
@@ -104,16 +104,14 @@ class PolylinePainter extends CustomPainter {
     final borderPaint = polylineOpt.borderStrokeWidth > 0.0
         ? (Paint()
           ..color = polylineOpt.borderColor
-          ..strokeWidth =
-              polylineOpt.strokeWidth + polylineOpt.borderStrokeWidth)
+          ..strokeWidth = polylineOpt.strokeWidth + polylineOpt.borderStrokeWidth)
         : null;
     var radius = polylineOpt.strokeWidth / 2;
     var borderRadius = radius + (polylineOpt.borderStrokeWidth / 2);
     if (polylineOpt.isDotted) {
       var spacing = polylineOpt.strokeWidth * 1.5;
       if (borderPaint != null) {
-        _paintDottedLine(
-            canvas, polylineOpt.offsets, borderRadius, spacing, borderPaint);
+        _paintDottedLine(canvas, polylineOpt.offsets, borderRadius, spacing, borderPaint);
       }
       _paintDottedLine(canvas, polylineOpt.offsets, radius, spacing, paint);
     } else {
@@ -124,8 +122,7 @@ class PolylinePainter extends CustomPainter {
     }
   }
 
-  void _paintDottedLine(Canvas canvas, List<Offset> offsets, double radius,
-      double stepLength, Paint paint) {
+  void _paintDottedLine(Canvas canvas, List<Offset> offsets, double radius, double stepLength, Paint paint) {
     var startDistance = 0.0;
     for (var i = 0; i < offsets.length - 1; i++) {
       var o0 = offsets[i];
@@ -139,15 +136,12 @@ class PolylinePainter extends CustomPainter {
         canvas.drawCircle(offset, radius, paint);
         distance += stepLength;
       }
-      startDistance = distance < totalDistance
-          ? stepLength - (totalDistance - distance)
-          : distance - totalDistance;
+      startDistance = distance < totalDistance ? stepLength - (totalDistance - distance) : distance - totalDistance;
     }
     canvas.drawCircle(polylineOpt.offsets.last, radius, paint);
   }
 
-  void _paintLine(
-      Canvas canvas, List<Offset> offsets, double radius, Paint paint) {
+  void _paintLine(Canvas canvas, List<Offset> offsets, double radius, Paint paint) {
     canvas.drawPoints(PointMode.lines, offsets, paint);
     for (var offset in offsets) {
       canvas.drawCircle(offset, radius, paint);

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -8,8 +8,11 @@ import 'package:latlong/latlong.dart';
 
 class PolylineLayerOptions extends LayerOptions {
   final List<Polyline> polylines;
-  PolylineLayerOptions({this.polylines = const [], rebuild})
-      : super(rebuild: rebuild);
+
+  PolylineLayerOptions({
+    this.polylines = const [],
+    Stream<void> rebuild,
+  }) : super(rebuild: rebuild);
 }
 
 class Polyline {
@@ -34,7 +37,7 @@ class Polyline {
 class PolylineLayer extends StatelessWidget {
   final PolylineLayerOptions polylineOpts;
   final MapState map;
-  final Stream<Null> stream;
+  final Stream<void> stream;
 
   PolylineLayer(this.polylineOpts, this.map, this.stream);
 

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -482,7 +482,9 @@ abstract class TileProvider {
 
   ImageProvider getImage(Coords coords, TileLayerOptions options);
 
-  dispose() {}
+  void dispose() {
+    //
+  }
 
   String _getTileUrl(Coords coords, TileLayerOptions options) {
     var data = <String, String>{

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -113,7 +113,7 @@ class TileLayerOptions extends LayerOptions {
 class TileLayer extends StatefulWidget {
   final TileLayerOptions options;
   final MapState mapState;
-  final Stream<Null> stream;
+  final Stream<void> stream;
 
   TileLayer({
     this.options,

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_image/network.dart';
 import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:flutter_map/src/core/util.dart' as util;
@@ -10,8 +12,6 @@ import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong/latlong.dart';
 import 'package:transparent_image/transparent_image.dart';
 import 'package:tuple/tuple.dart';
-import 'package:flutter_image/network.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 
 import 'layer.dart';
 
@@ -220,9 +220,8 @@ class _TileLayerState extends State<TileLayer> {
     var pixelBounds = _getTiledPixelBounds(center);
     var tileRange = _pxBoundsToTileRange(pixelBounds);
     var margin = options.keepBuffer ?? 2;
-    var noPruneRange = Bounds(
-        tileRange.bottomLeft - CustomPoint(margin, -margin),
-        tileRange.topRight + CustomPoint(margin, -margin));
+    var noPruneRange =
+        Bounds(tileRange.bottomLeft - CustomPoint(margin, -margin), tileRange.topRight + CustomPoint(margin, -margin));
     for (var tileKey in _tiles.keys) {
       var tile = _tiles[tileKey];
       var c = tile.coords;
@@ -285,27 +284,15 @@ class _TileLayerState extends State<TileLayer> {
     // wrapping
     _wrapX = crs.wrapLng;
     if (_wrapX != null) {
-      var first =
-          (map.project(LatLng(0.0, crs.wrapLng.item1), tileZoom).x / tileSize.x)
-              .floor()
-              .toDouble();
-      var second =
-          (map.project(LatLng(0.0, crs.wrapLng.item2), tileZoom).x / tileSize.y)
-              .ceil()
-              .toDouble();
+      var first = (map.project(LatLng(0.0, crs.wrapLng.item1), tileZoom).x / tileSize.x).floor().toDouble();
+      var second = (map.project(LatLng(0.0, crs.wrapLng.item2), tileZoom).x / tileSize.y).ceil().toDouble();
       _wrapX = Tuple2(first, second);
     }
 
     _wrapY = crs.wrapLat;
     if (_wrapY != null) {
-      var first =
-          (map.project(LatLng(crs.wrapLat.item1, 0.0), tileZoom).y / tileSize.x)
-              .floor()
-              .toDouble();
-      var second =
-          (map.project(LatLng(crs.wrapLat.item2, 0.0), tileZoom).y / tileSize.y)
-              .ceil()
-              .toDouble();
+      var first = (map.project(LatLng(crs.wrapLat.item1, 0.0), tileZoom).y / tileSize.x).floor().toDouble();
+      var second = (map.project(LatLng(crs.wrapLat.item2, 0.0), tileZoom).y / tileSize.y).ceil().toDouble();
       _wrapY = Tuple2(first, second);
     }
   }
@@ -402,10 +389,8 @@ class _TileLayerState extends State<TileLayer> {
     var crs = map.options.crs;
     if (!crs.infinite) {
       var bounds = _globalTileRange;
-      if ((crs.wrapLng == null &&
-              (coords.x < bounds.min.x || coords.x > bounds.max.x)) ||
-          (crs.wrapLat == null &&
-              (coords.y < bounds.min.y || coords.y > bounds.max.y))) {
+      if ((crs.wrapLng == null && (coords.x < bounds.min.x || coords.x > bounds.max.x)) ||
+          (crs.wrapLat == null && (coords.y < bounds.min.y || coords.y > bounds.max.y))) {
         return false;
       }
     }
@@ -433,9 +418,7 @@ class _TileLayerState extends State<TileLayer> {
         child: FadeInImage(
           fadeInDuration: const Duration(milliseconds: 100),
           key: Key(_tileCoordsToKey(coords)),
-          placeholder: options.placeholderImage != null
-              ? options.placeholderImage
-              : MemoryImage(kTransparentImage),
+          placeholder: options.placeholderImage != null ? options.placeholderImage : MemoryImage(kTransparentImage),
           image: options.tileProvider.getImage(coords, options),
           fit: BoxFit.fill,
         ),
@@ -445,12 +428,8 @@ class _TileLayerState extends State<TileLayer> {
 
   Coords _wrapCoords(Coords coords) {
     var newCoords = Coords(
-      _wrapX != null
-          ? util.wrapNum(coords.x.toDouble(), _wrapX)
-          : coords.x.toDouble(),
-      _wrapY != null
-          ? util.wrapNum(coords.y.toDouble(), _wrapY)
-          : coords.y.toDouble(),
+      _wrapX != null ? util.wrapNum(coords.x.toDouble(), _wrapX) : coords.x.toDouble(),
+      _wrapY != null ? util.wrapNum(coords.y.toDouble(), _wrapY) : coords.y.toDouble(),
     );
     newCoords.z = coords.z.toDouble();
     return newCoords;
@@ -515,8 +494,7 @@ abstract class TileProvider {
     if (options.tms) {
       data['y'] = invertY(coords.y.round(), coords.z.round()).toString();
     }
-    var allOpts = Map<String, String>.from(data)
-      ..addAll(options.additionalOptions);
+    var allOpts = Map<String, String>.from(data)..addAll(options.additionalOptions);
     return util.template(options.urlTemplate, allOpts);
   }
 

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -1,3 +1,4 @@
+import 'package:async/async.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/point.dart';
@@ -6,7 +7,6 @@ import 'package:flutter_map/src/layer/group_layer.dart';
 import 'package:flutter_map/src/layer/overlay_image_layer.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:positioned_tap_detector/positioned_tap_detector.dart';
-import 'package:async/async.dart';
 
 class FlutterMapState extends MapGestureMixin {
   final MapControllerImpl mapController;
@@ -54,13 +54,9 @@ class FlutterMapState extends MapGestureMixin {
   @override
   Widget build(BuildContext context) {
     _dispose();
-    return LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-      mapState.size =
-          CustomPoint<double>(constraints.maxWidth, constraints.maxHeight);
-      var layerWidgets = widget.layers
-          .map((layer) => _createLayer(layer, widget.options.plugins))
-          .toList();
+    return LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
+      mapState.size = CustomPoint<double>(constraints.maxWidth, constraints.maxHeight);
+      var layerWidgets = widget.layers.map((layer) => _createLayer(layer, widget.options.plugins)).toList();
 
       var layerWidgetsContainer = Container(
         width: constraints.maxWidth,
@@ -90,8 +86,7 @@ class FlutterMapState extends MapGestureMixin {
 
   Widget _createLayer(LayerOptions options, List<MapPlugin> plugins) {
     if (options is TileLayerOptions) {
-      return TileLayer(
-          options: options, mapState: mapState, stream: _merge(options));
+      return TileLayer(options: options, mapState: mapState, stream: _merge(options));
     }
     if (options is MarkerLayerOptions) {
       return MarkerLayer(options, mapState, _merge(options));

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -10,7 +10,7 @@ import 'package:positioned_tap_detector/positioned_tap_detector.dart';
 
 class FlutterMapState extends MapGestureMixin {
   final MapControllerImpl mapController;
-  final List<StreamGroup<Null>> groups = <StreamGroup<Null>>[];
+  final List<StreamGroup<void>> groups = <StreamGroup<void>>[];
 
   @override
   MapOptions get options => widget.options ?? MapOptions();
@@ -41,10 +41,10 @@ class FlutterMapState extends MapGestureMixin {
     super.dispose();
   }
 
-  Stream<Null> _merge(LayerOptions options) {
+  Stream<void> _merge(LayerOptions options) {
     if (options?.rebuild == null) return mapState.onMoved;
 
-    var group = StreamGroup<Null>();
+    var group = StreamGroup<void>();
     group.add(mapState.onMoved);
     group.add(options.rebuild);
     groups.add(group);

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -8,14 +8,12 @@ import 'package:flutter_map/src/core/center_zoom.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:latlong/latlong.dart';
 
-import 'package:flutter/material.dart';
-
 class MapControllerImpl implements MapController {
-  final Completer<Null> _readyCompleter = Completer<Null>();
+  final Completer<void> _readyCompleter = Completer<void>();
   MapState _state;
 
   @override
-  Future<Null> get onReady => _readyCompleter.future;
+  Future<void> get onReady => _readyCompleter.future;
 
   set state(MapState state) {
     _state = state;
@@ -52,7 +50,7 @@ class MapControllerImpl implements MapController {
 
 class MapState {
   final MapOptions options;
-  final StreamController<Null> _onMoveSink;
+  final StreamController<void> _onMoveSink;
 
   double _zoom;
 
@@ -67,7 +65,7 @@ class MapState {
 
   CustomPoint _size;
 
-  Stream<Null> get onMoved => _onMoveSink.stream;
+  Stream<void> get onMoved => _onMoveSink.stream;
 
   CustomPoint get size => _size;
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/core/center_zoom.dart';
@@ -31,8 +32,7 @@ class MapControllerImpl implements MapController {
   @override
   void fitBounds(
     LatLngBounds bounds, {
-    FitBoundsOptions options =
-        const FitBoundsOptions(padding: EdgeInsets.all(12.0)),
+    FitBoundsOptions options = const FitBoundsOptions(padding: EdgeInsets.all(12.0)),
   }) {
     _state.fitBounds(bounds, options);
   }
@@ -114,7 +114,8 @@ class MapState {
             bounds: bounds,
             zoom: zoom,
           ),
-          hasGesture, isUserGesture);
+          hasGesture,
+          isUserGesture);
     }
   }
 
@@ -161,12 +162,9 @@ class MapState {
     );
   }
 
-  CenterZoom _getBoundsCenterZoom(
-      LatLngBounds bounds, FitBoundsOptions options) {
-    var paddingTL =
-        CustomPoint<double>(options.padding.left, options.padding.top);
-    var paddingBR =
-        CustomPoint<double>(options.padding.right, options.padding.bottom);
+  CenterZoom _getBoundsCenterZoom(LatLngBounds bounds, FitBoundsOptions options) {
+    var paddingTL = CustomPoint<double>(options.padding.left, options.padding.top);
+    var paddingBR = CustomPoint<double>(options.padding.right, options.padding.bottom);
 
     var paddingTotalXY = paddingTL + paddingBR;
 
@@ -183,8 +181,7 @@ class MapState {
     );
   }
 
-  double getBoundsZoom(LatLngBounds bounds, CustomPoint<double> padding,
-      {bool inside = false}) {
+  double getBoundsZoom(LatLngBounds bounds, CustomPoint<double> padding, {bool inside = false}) {
     var zoom = this.zoom ?? 0.0;
     var min = options.minZoom ?? 0.0;
     var max = options.maxZoom ?? double.infinity;

--- a/lib/src/plugins/plugin.dart
+++ b/lib/src/plugins/plugin.dart
@@ -4,5 +4,6 @@ import 'package:flutter_map/src/map/map.dart';
 
 abstract class MapPlugin {
   bool supportsLayer(LayerOptions options);
-  Widget createLayer(LayerOptions options, MapState mapState, Stream<Null> stream);
+
+  Widget createLayer(LayerOptions options, MapState mapState, Stream<void> stream);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A Dart implementation of Leaflet for Flutter apps
-version: 0.5.3
+version: 0.6.0
 authors:
 - John Ryan <john.p.ryan4@gmail.com>
 homepage: https://github.com/apptreesoftware/flutter_map

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ homepage: https://github.com/apptreesoftware/flutter_map
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
+  flutter: ">=1.5.9-pre.94 <2.0.0"
 
 dependencies:
   flutter:
@@ -16,7 +17,7 @@ dependencies:
   positioned_tap_detector: ^1.0.2
   transparent_image: ^1.0.0
   async: ^2.1.0
-  flutter_image: ^1.0.0
+  flutter_image: ^2.0.0-dev.1
   cached_network_image: ^0.8.0
   sqflite: ^1.1.5
   path_provider: ^0.5.0+1


### PR DESCRIPTION
Hey @johnpryan,
Similar changes have already been made to `flutter_svg` see https://github.com/dnfield/flutter_svg/blob/master/CHANGELOG.md#0130

This is required for Flutter SDK v1.5.9 and above. I've also done a few cleanup things and bug-fixes. I've migrated the Streams for Stream<Null> to Stream<void>, although this is not a breaking change and should be compatible with external implementations of the TileOptions API. I've bumped the version to 0.6.0 according to semver.

Hit me up on Slack if you want to discuss. 
