### PR TITLE
Flutter 1.6.3 compatibility

### DIFF
--- a/lib/src/layer/mbtiles/mbtiles_image_provider.dart
+++ b/lib/src/layer/mbtiles/mbtiles_image_provider.dart
@@ -90,9 +90,8 @@ class MBTileImage extends ImageProvider<MBTileImage> {
     return MultiFrameImageStreamCompleter(
         codec: _loadAsync(key),
         scale: 1,
-        informationCollector: (StringBuffer information) {
-          information.writeln('Image provider: $this');
-          information.write('Image key: $key');
+        informationCollector: () {
+          return [DiagnosticsNode.message('Image provider: $this'), DiagnosticsNode.message('Image key: $key')];
         });
   }
 

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -37,10 +37,10 @@ Future<ui.Image> _loadImage(img.ImageProvider imageProvider) async {
   void listener(img.ImageInfo frame, bool synchronousCall) {
     var image = frame.image;
     completer.complete(image);
-    stream.removeListener(listener);
+    stream.removeListener(img.ImageStreamListener(listener));
   }
 
-  stream.addListener(listener);
+  stream.addListener(img.ImageStreamListener(listener));
   return completer.future;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   positioned_tap_detector: ^1.0.2
   transparent_image: ^1.0.0
   async: ^2.1.0
-  flutter_image: ^1.0.0
+  flutter_image: ^2.0.0-dev.1
   cached_network_image: ^0.8.0
   sqflite: ^1.1.5
   path_provider: ^0.5.0+1


### PR DESCRIPTION
Flutter 1.6.3 just hit the beta channel, and it contains some breaking changes.

This PR makes the bare minimum changes required to build under Flutter 1.6.3. I tested the example app on an iPhone and it seemed to work fine.