### PR TITLE
Changed Example Overlay Image Appbar title to match Drawer title

### DIFF
--- a/example/lib/pages/overlay_image.dart
+++ b/example/lib/pages/overlay_image.dart
@@ -18,7 +18,7 @@ class OverlayImagePage extends StatelessWidget {
     ];
 
     return Scaffold(
-      appBar: AppBar(title: Text('Circle')),
+      appBar: AppBar(title: Text('Overlay Image')),
       drawer: buildDrawer(context, route),
       body: Padding(
         padding: EdgeInsets.all(8.0),


### PR DESCRIPTION
Minor cosmetic update:
I noticed the the Appbar title on the Overlay Image page was 'Circle' and updated it to 'Overlay Image' so it matches its title in the Drawer widget.  

Thanks for the awesome Repo!