### PR TITLE
rotation added

### DIFF
--- a/example/lib/pages/map_controller.dart
+++ b/example/lib/pages/map_controller.dart
@@ -20,6 +20,7 @@ class MapControllerPageState extends State<MapControllerPage> {
   static LatLng dublin = LatLng(53.3498, -6.2603);
 
   MapController mapController;
+  double rotation = 0.0;
 
   @override
   void initState() {
@@ -129,6 +130,20 @@ class MapControllerPageState extends State<MapControllerPage> {
                       ));
                     },
                   ),
+                  Text('Rotation:'),
+                  Expanded(
+                    child: Slider(
+                      value: rotation,
+                      min: 0.0,
+                      max: 360,
+                      onChanged: (degree) {
+                        setState(() {
+                          rotation = degree;
+                        });
+                        mapController.rotate(degree);
+                      },
+                    ),
+                  )
                 ],
               ),
             ),

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -55,6 +55,8 @@ class FlutterMap extends StatefulWidget {
 abstract class MapController {
   /// Moves the map to a specific location and zoom level
   void move(LatLng center, double zoom);
+  void rotate(double degree);
+
   void fitBounds(
     LatLngBounds bounds, {
     FitBoundsOptions options,
@@ -64,6 +66,8 @@ abstract class MapController {
   LatLng get center;
   LatLngBounds get bounds;
   double get zoom;
+
+  ValueChanged<double> onRotationChanged;
 
   factory MapController() => MapControllerImpl();
 }
@@ -76,6 +80,7 @@ typedef void PositionCallback(
 class MapOptions {
   final Crs crs;
   final double zoom;
+  final double rotation;
   final double minZoom;
   final double maxZoom;
   final bool debug;
@@ -92,6 +97,7 @@ class MapOptions {
     this.crs = const Epsg3857(),
     this.center,
     this.zoom = 13.0,
+    this.rotation = 0.0,
     this.minZoom,
     this.maxZoom,
     this.debug = false,

--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map/src/gestures/latlng_tween.dart';
 import 'package:flutter_map/src/map/map.dart';
 import 'package:latlong/latlong.dart';
 import 'package:positioned_tap_detector/positioned_tap_detector.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 abstract class MapGestureMixin extends State<FlutterMap>
     with TickerProviderStateMixin {
@@ -46,7 +47,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
       _mapCenterStart = map.center;
 
       // determine the focal point within the widget
-      final focalOffset = details.focalPoint - _mapOffset;
+      final focalOffset = details.localFocalPoint;
       _focalStartLocal = _offsetToPoint(focalOffset);
       _focalStartGlobal = _offsetToCrs(focalOffset);
 
@@ -56,7 +57,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
 
   void handleScaleUpdate(ScaleUpdateDetails details) {
     setState(() {
-      final focalOffset = _offsetToPoint(details.focalPoint - _mapOffset);
+      final focalOffset = _offsetToPoint(details.localFocalPoint);
       final newZoom = _getZoomForScale(_mapZoomStart, details.scale);
       final focalStartPt = map.project(_focalStartGlobal, newZoom);
       final newCenterPt = focalStartPt - focalOffset + map.size / 2.0;
@@ -188,6 +189,7 @@ abstract class MapGestureMixin extends State<FlutterMap>
     return Offset(point.x.toDouble(), point.y.toDouble());
   }
 
+  // This is no longer needed
   Offset get _mapOffset =>
       (context.findRenderObject() as RenderBox).localToGlobal(Offset.zero);
 

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -379,10 +380,10 @@ class _TileLayerState extends State<TileLayer> {
     }
 
     return Container(
+      color: options.backgroundColor,
       child: Stack(
         children: tileWidgets,
       ),
-      color: options.backgroundColor,
     );
   }
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -50,6 +50,12 @@ class MapControllerImpl implements MapController {
 
   @override
   double get zoom => _state.zoom;
+
+  @override
+  void rotate(double degree) => onRotationChanged(degree);
+
+  @override
+  ValueChanged<double> onRotationChanged;
 }
 
 class MapState {


### PR DESCRIPTION
Hi, 
I added rotation functionality to the map.
Not exactly like asked in https://github.com/johnpryan/flutter_map/issues/116

Because I don't see a lot of benefit of enabling the user to rotate the map but to rotate the map from the app side e.g. connected to the compass.
So the mapController got a rotate function and the map option an initial rotation.
The rotation is done at the outmost scope so I rotate the whole map with all it's layer because it don't make sense for a single layer not to rotate.

I did not change the version, I let that to you when publishing :-)

I hope you like it.