### PR TITLE
fixed exception during initialization

### DIFF
--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -88,11 +88,11 @@ class MapState {
 
   set size(CustomPoint s) {
     _size = s;
-    _pixelOrigin = getNewPixelOrigin(_lastCenter);
     if (!_initialized) {
       _init();
       _initialized = true;
     }
+    _pixelOrigin = getNewPixelOrigin(_lastCenter);
   }
 
   LatLng get center => getCenter() ?? options.center;
@@ -115,7 +115,7 @@ class MapState {
     zoom = _fitZoomToBounds(zoom);
     final mapMoved = center != _lastCenter || zoom != _zoom;
 
-    if (!mapMoved || options.isOutOfBounds(center) || !bounds.isValid) {
+    if (_lastCenter != null && (!mapMoved || options.isOutOfBounds(center) || !bounds.isValid)) {
       return;
     }
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -115,7 +115,8 @@ class MapState {
     zoom = _fitZoomToBounds(zoom);
     final mapMoved = center != _lastCenter || zoom != _zoom;
 
-    if (_lastCenter != null && (!mapMoved || options.isOutOfBounds(center) || !bounds.isValid)) {
+    if (_lastCenter != null &&
+        (!mapMoved || options.isOutOfBounds(center) || !bounds.isValid)) {
       return;
     }
 


### PR DESCRIPTION
Hi,

I observed that when you have enabled 'break on all exceptions' that flutter_map threw an exception while initializing due to that `_lastCenter` was not initialized. I changed a little bit the sequence and made sure that in this case `move`  is executed which initializes `_lastCenter` correctly.

IMHO it would be worth to have a closer look over the whole initialization process sometimes.