### PR TITLE
Add a more conservative boundary calculation

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -1,6 +1,7 @@
 library flutter_map;
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -150,4 +151,65 @@ class MapPosition {
   final bool hasGesture;
 
   MapPosition({this.center, this.bounds, this.zoom, this.hasGesture = false});
+}
+
+/// Extension that prevents any tiles outside the bounds from ever being
+/// displayed, regardless of zoom level
+class AdaptiveBoundariesMapOptions extends MapOptions {
+  static const double initialZoom = 13;
+
+  final Size screenSize;
+  final MapController controller;
+
+  AdaptiveBoundariesMapOptions({
+    @required this.screenSize,
+    @required this.controller,
+    @required LatLng center,
+    @required double minZoom,
+    @required double maxZoom,
+    @required LatLng swPanBoundary,
+    @required LatLng nePanBoundary,
+  }) : super(
+          center: center,
+          minZoom: minZoom,
+          maxZoom: maxZoom,
+          swPanBoundary: swPanBoundary,
+          nePanBoundary: nePanBoundary,
+          zoom: initialZoom,
+        );
+
+  /// More conservative calculation which accounts for screen size
+  @override
+  bool isOutOfBounds(LatLng point) {
+    final screenWidthInDegrees = _calculateScreenWidthInDegrees();
+    final screenHeightInDegrees = _calculateScreenHeightInDegrees();
+    final corners =
+        _getCornerCoordinates(screenHeightInDegrees, screenWidthInDegrees);
+    return corners.any(super.isOutOfBounds);
+  }
+
+  Iterable<LatLng> _getCornerCoordinates(
+      double screenHeightInDegrees, double screenWidthInDegrees) sync* {
+    final halfScreenHeight = screenHeightInDegrees / 2;
+    final halfScreenWidth = screenWidthInDegrees / 2;
+    const signs = [-1, 1];
+    for (var latSign in signs) {
+      for (var lonSign in signs) {
+        yield LatLng(center.latitude + latSign * halfScreenHeight,
+            center.longitude + lonSign * halfScreenWidth);
+      }
+    }
+  }
+
+  double _calculateScreenWidthInDegrees() {
+    final zoom = _getControllerZoom();
+    final degreesPerPixel = 360 / pow(2, zoom + 8);
+    return screenSize.width * degreesPerPixel;
+  }
+
+  double _calculateScreenHeightInDegrees() =>
+      screenSize.height * 180 / pow(2, _getControllerZoom() + 8) * 4 / 3;
+
+  double _getControllerZoom() =>
+      controller.ready ? controller.zoom : initialZoom;
 }


### PR DESCRIPTION
Prevents tiles outside the boundaries from showing up at all.

With the current implementation, it is still possible to have up to three quarters of map area outside the specified boundaries on screen.