### PR TITLE
Add a more conservative boundary calculation

### DIFF
--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -210,17 +210,13 @@ class AdaptiveBoundariesMapOptions extends MapOptions {
   /// More conservative calculation which accounts for screen size
   @override
   bool isOutOfBounds(LatLng point) {
-    final screenWidthInDegrees = _calculateScreenWidthInDegrees();
-    final screenHeightInDegrees = _calculateScreenHeightInDegrees();
-    final corners = _getCornerCoordinates(
-        screenHeightInDegrees, screenWidthInDegrees, point);
+    final corners = _getCornerCoordinates(point);
     return corners.any(super.isOutOfBounds);
   }
 
-  Iterable<LatLng> _getCornerCoordinates(double screenHeightInDegrees,
-      double screenWidthInDegrees, LatLng point) sync* {
-    final halfScreenHeight = screenHeightInDegrees / 2;
-    final halfScreenWidth = screenWidthInDegrees / 2;
+  Iterable<LatLng> _getCornerCoordinates(LatLng point) sync* {
+    final halfScreenHeight = _calculateScreenWidthInDegrees() / 2;
+    final halfScreenWidth = _calculateScreenHeightInDegrees() / 2;
     const signs = [-1, 1];
     for (var latSign in signs) {
       for (var lonSign in signs) {

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -212,20 +212,20 @@ class AdaptiveBoundariesMapOptions extends MapOptions {
   bool isOutOfBounds(LatLng point) {
     final screenWidthInDegrees = _calculateScreenWidthInDegrees();
     final screenHeightInDegrees = _calculateScreenHeightInDegrees();
-    final corners =
-        _getCornerCoordinates(screenHeightInDegrees, screenWidthInDegrees);
+    final corners = _getCornerCoordinates(
+        screenHeightInDegrees, screenWidthInDegrees, point);
     return corners.any(super.isOutOfBounds);
   }
 
-  Iterable<LatLng> _getCornerCoordinates(
-      double screenHeightInDegrees, double screenWidthInDegrees) sync* {
+  Iterable<LatLng> _getCornerCoordinates(double screenHeightInDegrees,
+      double screenWidthInDegrees, LatLng point) sync* {
     final halfScreenHeight = screenHeightInDegrees / 2;
     final halfScreenWidth = screenWidthInDegrees / 2;
     const signs = [-1, 1];
     for (var latSign in signs) {
       for (var lonSign in signs) {
-        yield LatLng(center.latitude + latSign * halfScreenHeight,
-            center.longitude + lonSign * halfScreenWidth);
+        yield LatLng(point.latitude + latSign * halfScreenHeight,
+            point.longitude + lonSign * halfScreenWidth);
       }
     }
   }


### PR DESCRIPTION
Prevents the case where up to three quarters of map area outside the specified boundaries are displayed.