### PR TITLE
Fix error when unproject bottomLeft or topRight  and lat are < -90 or > 90 or lng are < -180 or > 180

### DIFF
--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/rendering.dart';
 import 'package:tuple/tuple.dart';
 import 'package:latlong/latlong.dart';
 import 'package:flutter_map/src/core/bounds.dart';
@@ -120,6 +122,14 @@ abstract class Projection {
   Bounds<double> get bounds;
   CustomPoint project(LatLng latlng);
   LatLng unproject(CustomPoint point);
+
+  @protected
+  double inclusive(double value) {
+    if (value.compareTo(-90) < 0) return -90;
+    if (value.compareTo(90) > 0) return 90;
+
+    return value;
+  }
 }
 
 class _LonLat extends Projection {
@@ -138,7 +148,7 @@ class _LonLat extends Projection {
 
   @override
   LatLng unproject(CustomPoint point) {
-    return LatLng(point.y, point.x);
+    return LatLng(inclusive(point.y), inclusive(point.x));
   }
 }
 
@@ -170,8 +180,9 @@ class SphericalMercator extends Projection {
   @override
   LatLng unproject(CustomPoint point) {
     var d = 180 / math.pi;
-    return LatLng((2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d,
-        point.x * d / r);
+    return LatLng(
+        inclusive((2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d),
+        inclusive(point.x * d / r));
   }
 }
 

--- a/lib/src/geo/crs/crs.dart
+++ b/lib/src/geo/crs/crs.dart
@@ -123,10 +123,22 @@ abstract class Projection {
   CustomPoint project(LatLng latlng);
   LatLng unproject(CustomPoint point);
 
+  double _inclusive(Comparable start, Comparable end, double value) {
+    if (value.compareTo(start) < 0) return start;
+    if (value.compareTo(end) > 0) return end;
+
+    return value;
+  }
+
   @protected
-  double inclusive(double value) {
-    if (value.compareTo(-90) < 0) return -90;
-    if (value.compareTo(90) > 0) return 90;
+  double inclusiveLat(double value) {
+    return _inclusive(-90.0, 90.0, value);
+  }
+
+  @protected
+  double inclusiveLng(double value) {
+    if (value.compareTo(-180) < 0) return -180;
+    if (value.compareTo(180) > 0) return 180;
 
     return value;
   }
@@ -148,7 +160,7 @@ class _LonLat extends Projection {
 
   @override
   LatLng unproject(CustomPoint point) {
-    return LatLng(inclusive(point.y), inclusive(point.x));
+    return LatLng(inclusiveLat(point.y), inclusiveLng(point.x));
   }
 }
 
@@ -181,8 +193,9 @@ class SphericalMercator extends Projection {
   LatLng unproject(CustomPoint point) {
     var d = 180 / math.pi;
     return LatLng(
-        inclusive((2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d),
-        inclusive(point.x * d / r));
+        inclusiveLat(
+            (2 * math.atan(math.exp(point.y / r)) - (math.pi / 2)) * d),
+        inclusiveLng(point.x * d / r));
   }
 }
 


### PR DESCRIPTION
I'have a tablet and when i put FlutterMap with zoom: 1 and minzoom: 1, debug catch a throw in LatLng class because latitude or longitude are invalid ( lat < -90 or > 90 or lng < -180 or > 180). So i inserted a control before, when i unproject the point in pixel. With this fix it doesn't give error when i drag the map outside to the screen.