### PR TITLE
Issue 290 : Add example of showing current location

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,8 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -26,7 +25,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.johnpryan.leafletflutterexample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.google.gms:google-services:4.2.0'
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import './pages/animated_map_controller.dart';
 import './pages/circle.dart';
 import './pages/esri.dart';
 import './pages/home.dart';
+import './pages/live_location.dart';
 import './pages/map_controller.dart';
 import './pages/marker_anchor.dart';
 import './pages/moving_markers.dart';
@@ -44,6 +45,7 @@ class MyApp extends StatelessWidget {
         MovingMarkersPage.route: (context) => MovingMarkersPage(),
         CirclePage.route: (context) => CirclePage(),
         OverlayImagePage.route: (context) => OverlayImagePage(),
+        LiveLocationPage.route: (context) => LiveLocationPage(),
       },
     );
   }

--- a/example/lib/pages/live_location.dart
+++ b/example/lib/pages/live_location.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong/latlong.dart';
+import 'package:location/location.dart';
+
+class LiveLocationPage extends StatefulWidget {
+  static const String route = '/live_location';
+
+  @override
+  _LiveLocationPageState createState() => _LiveLocationPageState();
+}
+
+class _LiveLocationPageState extends State<LiveLocationPage> {
+
+  LocationData _currentLocation;
+  MapController _mapController;
+
+  bool _liveUpdate = true;
+  bool _permission = false;
+
+  String _serviceError = '';
+
+  final Location _locationService = Location();
+
+  @override
+  void initState() {
+    super.initState();
+    _mapController = MapController();
+    initLocationService();
+  }
+
+  void initLocationService() async {
+    await _locationService.changeSettings(
+      accuracy: LocationAccuracy.HIGH,
+      interval: 1000,
+    );
+
+    LocationData location;
+    bool serviceEnabled;
+    bool serviceRequestResult;
+
+    try {
+      serviceEnabled = await _locationService.serviceEnabled();
+
+      if (serviceEnabled) {
+        _permission = await _locationService.requestPermission();
+
+        if (_permission) {
+          location = await _locationService.getLocation();
+          _currentLocation = location;
+          _locationService.onLocationChanged().listen((LocationData result) async {
+            if (mounted) {
+              setState(() {
+                _currentLocation = result;
+
+                // If Live Update is enabled, move map center
+                if (_liveUpdate) {
+                  _mapController.move(
+                      LatLng(
+                          _currentLocation.latitude,
+                          _currentLocation.longitude),
+                      _mapController.zoom
+                  );
+                }
+              });
+            }
+          });
+        }
+      } else {
+        serviceRequestResult = await _locationService.requestService();
+        if(serviceRequestResult){
+          initLocationService();
+          return;
+        }
+      }
+    } on PlatformException catch (e) {
+      print(e);
+      if (e.code == 'PERMISSION_DENIED') {
+        _serviceError = e.message;
+      } else if (e.code == 'SERVICE_STATUS_ERROR') {
+        _serviceError = e.message;
+      }
+      location = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    LatLng currentLatLng;
+
+    // Until currentLocation is initially updated, Widget can locate to 0, 0
+    // by default or store previous location value to show.
+    if (_currentLocation != null) {
+      currentLatLng = LatLng(_currentLocation.latitude, _currentLocation.longitude);
+    } else {
+      currentLatLng = LatLng(0, 0);
+    }
+
+    var markers = <Marker>[
+      Marker(
+        width: 80.0,
+        height: 80.0,
+        point: currentLatLng,
+        builder: (ctx) => Container(
+          child: FlutterLogo(
+            colors: Colors.blue,
+            key: ObjectKey(Colors.blue),
+          ),
+        ),
+      ),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Home')),
+      //drawer: buildDrawer(context, route),
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: _serviceError.isEmpty ?
+                Text('This is a map that is showing '
+                  '(${currentLatLng.latitude}, ${currentLatLng.longitude}).') :
+                Text('Error occured while acquiring location. Error Message : '
+                    '$_serviceError'),
+            ),
+            Flexible(
+              child: FlutterMap(
+                mapController: _mapController,
+                options: MapOptions(
+                  center: LatLng(currentLatLng.latitude, currentLatLng.longitude),
+                  zoom: 5.0,
+                ),
+                layers: [
+                  TileLayerOptions(
+                    urlTemplate:
+                    'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                    // For example purposes. It is recommended to use
+                    // TileProvider with a caching and retry strategy, like
+                    // NetworkTileProvider or CachedNetworkTileProvider
+                    tileProvider: NonCachingNetworkTileProvider(),
+                  ),
+                  MarkerLayerOptions(markers: markers)
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+          onPressed: () => _liveUpdate = !_liveUpdate,
+          child: _liveUpdate ? Icon(Icons.location_on) : Icon(Icons.location_off),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -4,6 +4,7 @@ import '../pages/animated_map_controller.dart';
 import '../pages/circle.dart';
 import '../pages/esri.dart';
 import '../pages/home.dart';
+import '../pages/live_location.dart';
 import '../pages/map_controller.dart';
 import '../pages/marker_anchor.dart';
 import '../pages/moving_markers.dart';
@@ -130,6 +131,13 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           selected: currentRoute == OverlayImagePage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, OverlayImagePage.route);
+          },
+        ),
+        ListTile(
+          title: const Text('Live Location Update'),
+          selected: currentRoute == LiveLocationPage.route,
+          onTap: () {
+            Navigator.pushReplacementNamed(context, LiveLocationPage.route);
           },
         ),
       ],

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,6 +7,7 @@ dependencies:
   cupertino_icons: ^0.1.0
   flutter_map:
     path: ../
+  location: ^2.3.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#290  Add example page that use [flutterlocation](https://pub.dev/packages/location) to achieve device's location and update it in live. 

* I need a confirm that upgrading sample app's requirements is okay or not. Because I had really hard time with debugging "location" library and finally got a reason why it was not running okay with flutter_map sample app.

https://pub.dev/packages/location#breaking-changes

as described on README page, location version 2 uses AndroidX and SDK 28 to run it. 

If you guys think it's too unnecessary, I might can try "location" version 1 to integrate.

I will include build.gradle commits for now.