### PR TITLE
updated cached_network_image plugin to use 2.0.0-rc

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   transparent_image: ^1.0.0
   async: ^2.1.0
   flutter_image: ^2.0.0
-  cached_network_image: ^1.1.0
+  cached_network_image: ^2.0.0-rc
   sqflite: ^1.1.5
   path_provider: ^1.1.0
   vector_math: ^2.0.0


### PR DESCRIPTION
The Flutter team made a breaking change with the ImageProvider in Flutter 1.10.15 (currently Master channel only).