### PR TITLE
Adding an explanation when a plugin has not been activated

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -174,6 +174,11 @@ class FlutterMapState extends MapGestureMixin {
         return plugin.createLayer(options, mapState, _merge(options));
       }
     }
+    assert(false, """
+Can't find correct layer for $options. Perhaps when you create your FlutterMap you need something like this:
+
+    options: new MapOptions(plugins: [MyFlutterMapPlugin()])"""
+    );
     return null;
   }
 }


### PR DESCRIPTION
I spent a little while in the debugger trying to figure out why a plugin wasn't working.
The answer: I didn't include it in the options. Hopefully this will help. Optionally,
instead of returning null, this method could return some sort of null Widget, so that
a plugin issue doesn't cause the map to fail to render.