### PR TITLE
Fix various issues when upgrading flutter to latest stable release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 build/
 ios/.generated/
 packages
+.packages
 pubspec.lock
-.flutter-plugins
+.flutter-plugins*
 .vscode/
 GeneratedPluginRegistrant.h
 GeneratedPluginRegistrant.m
@@ -11,14 +12,15 @@ GeneratedPluginRegistrant.java
 ios/Flutter/Generated.xcconfig
 
 # Temp files in Example
-/flutter_map_example/.DS_Store
-/flutter_map_example/.atom/
-/flutter_map_example/.idea
-/flutter_map_example/.packages
-/flutter_map_example/.pub/
-/flutter_map_example/build/
-/flutter_map_example/ios/.generated/
-/flutter_map_example/packages
-/flutter_map_example/pubspec.lock
-/flutter_map_example/.flutter-plugins
-/flutter_map_example/.vscode/
+/example/.DS_Store
+/example/.atom/
+/example/.idea
+/example/.packages
+/example/.pub/
+/example/build/
+/example/ios/.generated/
+/example/packages
+/example/pubspec.lock
+/example/.flutter-plugins
+/example/.vscode/
+**/ios/Flutter/flutter_export_environment.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - fonts-droid-fallback
 before_script:
   - git clone https://github.com/flutter/flutter.git -b stable ~/flutter
+  - ~/flutter/bin/flutter config --no-analytics
   - ~/flutter/bin/flutter doctor
 script:
   - ~/flutter/bin/cache/dart-sdk/bin/dartfmt --set-exit-if-changed -n .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.8.0] - 16/12/2019
+- Breaking change to support flutter 1.12.13+hotfix.5 on
+- Update support for new flutter_image method signature (#472, #473, #476)
+
 ## [0.7.3] - 10/3/2019
 - Update changelog (#408)
 - Readability improvements (#410)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Add flutter_map to your pubspec:
 ```yaml
 dependencies:
   flutter_map: any # or the latest version on Pub
+  #flutter_map: 0.7.3 # for flutter 1.12.13 and before
 ```
 
 Configure the map using `MapOptions` and layer options:

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -520,5 +520,5 @@ class Coords<T extends num> extends CustomPoint<T> {
   }
 
   @override
-  int get hashCode => hashValues(x.hashCode, y.hashCode, z.hashCode);
+  int get hashCode => x.hashCode ^ y.hashCode ^ z.hashCode;
 }

--- a/lib/src/layer/tile_provider/mbtiles_image_provider.dart
+++ b/lib/src/layer/tile_provider/mbtiles_image_provider.dart
@@ -87,7 +87,7 @@ class MBTileImage extends ImageProvider<MBTileImage> {
   MBTileImage(this.database, this.coords);
 
   @override
-  ImageStreamCompleter load(MBTileImage key) {
+  ImageStreamCompleter load(MBTileImage key, DecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
         codec: _loadAsync(key),
         scale: 1,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map
 description: A Dart implementation of Leaflet for Flutter apps
-version: 0.7.3
+version: 0.8.0
 authors:
 - John Ryan <john.p.ryan4@gmail.com>
 homepage: https://github.com/johnpryan/flutter_map
@@ -16,8 +16,8 @@ dependencies:
   positioned_tap_detector: ^1.0.2
   transparent_image: ^1.0.0
   async: ^2.1.0
-  flutter_image: ^2.0.0
-  cached_network_image: ^1.1.0
+  flutter_image: ^3.0.0
+  cached_network_image: ^2.0.0-rc
   sqflite: ^1.1.5
   path_provider: ^1.1.0
   vector_math: ^2.0.0


### PR DESCRIPTION
Breaking change - support `flutter 1.12.13+hotfix.5` and up.

- bump version to `0.8.0`;
- (#472, #473, #476) Fix new method signature for `flutter_image` `ImageProvider.load`. Upgrade `cached_network_image` to remove conflict;
- Update `.gitignore`, to ignore renamed example, and all new files, introduced by latest flutter;
- Update `README.md` to note users of old flutter to use version `0.7.3`.