### PR TITLE
fixes tiles at edge not being loaded, due to using the same tilezoom …

### DIFF
--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -272,7 +272,7 @@ class MapState {
   }
 
   Bounds getPixelBounds(double zoom) {
-    var mapZoom = zoom;
+    var mapZoom = this.zoom;
     var scale = getZoomScale(mapZoom, zoom);
     var pixelCenter = project(center, zoom).floor();
     var halfSize = size / (scale * 2);


### PR DESCRIPTION
I think there was a typo here, as it's just comparing itself to get a ratio of map zoom to tile zoom. So I think it needs to use a this.zoom instead. This hopefully fixes https://github.com/johnpryan/flutter_map/issues/517