### PR TITLE
Fix Bug 545 stacked MBTileImageProvider

### DIFF
--- a/lib/src/layer/tile_provider/mbtiles_image_provider.dart
+++ b/lib/src/layer/tile_provider/mbtiles_image_provider.dart
@@ -76,6 +76,7 @@ class MBTilesImageProvider extends TileProvider {
     return MBTileImage(
       database,
       Coords<int>(x, y)..z = z,
+      mbtilesFile?.path ?? asset,
     );
   }
 }
@@ -83,8 +84,9 @@ class MBTilesImageProvider extends TileProvider {
 class MBTileImage extends ImageProvider<MBTileImage> {
   final Future<Database> database;
   final Coords<int> coords;
+  final String fileUrl;
 
-  MBTileImage(this.database, this.coords);
+  MBTileImage(this.database, this.coords, this.fileUrl);
 
   @override
   ImageStreamCompleter load(MBTileImage key, decode) {
@@ -124,6 +126,6 @@ class MBTileImage extends ImageProvider<MBTileImage> {
 
   @override
   bool operator ==(other) {
-    return other is MBTileImage && coords == other.coords;
+    return other is MBTileImage && coords == other.coords && fileUrl == other.fileUrl;
   }
 }

--- a/lib/src/layer/tile_provider/mbtiles_image_provider.dart
+++ b/lib/src/layer/tile_provider/mbtiles_image_provider.dart
@@ -84,9 +84,9 @@ class MBTilesImageProvider extends TileProvider {
 class MBTileImage extends ImageProvider<MBTileImage> {
   final Future<Database> database;
   final Coords<int> coords;
-  final String fileUrl;
+  final String filePath;
 
-  MBTileImage(this.database, this.coords, this.fileUrl);
+  MBTileImage(this.database, this.coords, this.filePath);
 
   @override
   ImageStreamCompleter load(MBTileImage key, decode) {
@@ -126,6 +126,7 @@ class MBTileImage extends ImageProvider<MBTileImage> {
 
   @override
   bool operator ==(other) {
-    return other is MBTileImage && coords == other.coords && fileUrl == other.fileUrl;
+    return other is MBTileImage && coords == other.coords 
+      && filePath == other.filePath;
   }
 }


### PR DESCRIPTION
Added a third parameter to the MBTileImage to distinguish two different MBTileImages with the same coordinates.

Fixes #545 