### PR TITLE
Move plugins to front of checks, so they can override defaults

### DIFF
--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -147,6 +147,11 @@ class FlutterMapState extends MapGestureMixin {
   }
 
   Widget _createLayer(LayerOptions options, List<MapPlugin> plugins) {
+    for (var plugin in plugins) {
+      if (plugin.supportsLayer(options)) {
+        return plugin.createLayer(options, mapState, _merge(options));
+      }
+    }
     if (options is TileLayerOptions) {
       return TileLayer(
           options: options, mapState: mapState, stream: _merge(options));
@@ -168,11 +173,6 @@ class FlutterMapState extends MapGestureMixin {
     }
     if (options is OverlayImageLayerOptions) {
       return OverlayImageLayer(options, mapState, _merge(options));
-    }
-    for (var plugin in plugins) {
-      if (plugin.supportsLayer(options)) {
-        return plugin.createLayer(options, mapState, _merge(options));
-      }
     }
     return null;
   }


### PR DESCRIPTION
This simply moves the plugin check to the top of the layer check. This allows a different version of a layer to be used as a plugin, as it feels if you are including a plugin, it should take priority of selection.