### PR TITLE
Add an option for gapless playback on an OverlayImage

### DIFF
--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -68,6 +68,7 @@ class OverlayImageLayer extends StatelessWidget {
         fit: BoxFit.fill,
         color: Color.fromRGBO(255, 255, 255, overlayImage.opacity),
         colorBlendMode: BlendMode.modulate,
+        gaplessPlayback: true,
       ),
     );
   }

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -16,11 +16,13 @@ class OverlayImage {
   final LatLngBounds bounds;
   final ImageProvider imageProvider;
   final double opacity;
+  final bool gaplessPlayback;
 
   OverlayImage({
     this.bounds,
     this.imageProvider,
     this.opacity = 1.0,
+    this.gaplessPlayback = false,
   });
 }
 
@@ -68,7 +70,7 @@ class OverlayImageLayer extends StatelessWidget {
         fit: BoxFit.fill,
         color: Color.fromRGBO(255, 255, 255, overlayImage.opacity),
         colorBlendMode: BlendMode.modulate,
-        gaplessPlayback: true,
+        gaplessPlayback: overlayImage.gaplessPlayback,
       ),
     );
   }


### PR DESCRIPTION
Adding an option for setting the `gaplessPlayback` argument on `OverlayImage`'s `Image` widget allows animated overlays to render smoothly.

Note the flickering behaviour in the "before" example that doesn't occur in the "after" example. 

## Before

![before-small](https://user-images.githubusercontent.com/352291/77840407-efe42a80-71d2-11ea-8647-2dbd979dd64f.gif)


## After

![](https://user-images.githubusercontent.com/352291/77840398-d642e300-71d2-11ea-8d7f-0e49416239a0.gif)
