### PR TITLE
Improve tile management

### DIFF
--- a/lib/src/gestures/gestures.dart
+++ b/lib/src/gestures/gestures.dart
@@ -236,8 +236,11 @@ abstract class MapGestureMixin extends State<FlutterMap>
     return Offset(point.x.toDouble(), point.y.toDouble());
   }
 
-  double _getZoomForScale(double startZoom, double scale) =>
-      startZoom + math.log(scale) / math.ln2;
+  double _getZoomForScale(double startZoom, double scale) {
+    var resultZoom = startZoom + math.log(scale) / math.ln2;
+
+    return map.fitZoomToBounds(resultZoom);
+  }
 
   @override
   void dispose() {

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -392,15 +392,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       }
     }
 
-    // TODO: remove diagnostic
-    if (toRemove.isNotEmpty) {
-      print('_prune+abort ---------------------');
-    }
-
     for (var key in toRemove) {
       var tile = _tiles[key];
-      // TODO: remove diagnostic
-      print('_prune+abort: ${tile.coords}');
 
       tile.tileReady = null;
       tile.dispose();
@@ -468,9 +461,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
     var zoom = _tileZoom;
     if (zoom == null) {
-      // TODO: remove diagnostic
-      print('_removeAllTiles');
-
       _removeAllTiles();
       return;
     }
@@ -500,14 +490,7 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       }
     }
 
-    // TODO: remove diagnostic
-    if (toRemove.isNotEmpty) {
-      print('_prune ---------------------');
-    }
-
     for (var key in toRemove) {
-      // TODO: remove diagnostic
-      print('_prune: ${_tiles[key].coords}');
       _removeTile(key);
     }
   }
@@ -605,9 +588,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     var tileZoom = _clampZoom(zoom.roundToDouble());
     if ((options.maxZoom != null && tileZoom > options.maxZoom) ||
         (options.minZoom != null && tileZoom < options.minZoom)) {
-      // TODO: remove diagnostic
-      print('Zoom become null');
-
       tileZoom = null;
     }
 
@@ -688,11 +668,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       if ((options.maxZoom != null && tileZoom <= options.maxZoom) &&
           (options.minZoom != null && tileZoom >= options.minZoom)) {
         _tileZoom = tileZoom;
-
-        // It was a zoom lvl change
-        // TODO: remove diagnostic
-        print('Zoom restored from null to $tileZoom');
-
         setState(() {
           _setView(map.center, tileZoom);
         });
@@ -701,9 +676,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       setState(() {
         if ((tileZoom - _tileZoom).abs() >= 1) {
           // It was a zoom lvl change
-          // TODO: remove diagnostic
-          print('Zoom change: $_tileZoom --> ${tileZoom}');
-
           _setView(map.center, tileZoom);
         } else {
           if (null == _throttleUpdate) {
@@ -785,11 +757,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     queue.sort((a, b) =>
         (a.distanceTo(tileCenter) - b.distanceTo(tileCenter)).toInt());
 
-    // TODO: remove diagnostic
-    if (queue.isNotEmpty) {
-      print('_addTile ---------------------');
-    }
-
     for (var i = 0; i < queue.length; i++) {
       _addTile(queue[i]);
     }
@@ -835,9 +802,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 
   void _addTile(Coords<double> coords) {
-    // TODO: remove diagnostic
-    print('_fetch tile: $coords');
-
     var tileCoordsToKey = _tileCoordsToKey(coords);
     _tiles[tileCoordsToKey] = Tile(
       coords: coords,
@@ -968,7 +932,7 @@ class Tile implements Comparable<Tile> {
       _listener = ImageStreamListener(_tileOnLoad, onError: _tileOnError);
       _imageStream.addListener(_listener);
     } catch (e, s) {
-      // make sure all exception is handled - #444
+      // make sure all exception is handled - #444 / #536
       _tileOnError(e, s);
     }
   }

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -276,12 +276,11 @@ class _TileLayerState extends State<TileLayer> {
       _throttleUpdate = null;
     } else {
       _throttleUpdate = StreamController<LatLng>(sync: true);
-      util
-          .bindAndCreateThrottleStreamWithTrailingCall<LatLng>(
-            _throttleUpdate,
-            options.updateInterval,
-          )
-          .listen(_update);
+      _throttleUpdate.stream.transform(
+        util.throttleStreamTransformerWithTrailingCall<LatLng>(
+          options.updateInterval,
+        ),
+      )..listen(_update);
     }
   }
 

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -57,7 +57,10 @@ class TileLayerOptions extends LayerOptions {
   // from maxNativeZoom level and auto-scaled.
   final double maxNativeZoom;
 
+  // If set to true, the zoom number used in tile URLs will be reversed (`maxZoom - zoom` instead of `zoom`)
   final bool zoomReverse;
+
+  // The zoom number used in tile URLs will be offset with this value.
   final double zoomOffset;
 
   /// List of subdomains for the URL.

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -142,7 +142,7 @@ class TileLayerOptions extends LayerOptions {
       this.wmsOptions = null,
       this.opacity = 1.0,
       this.updateInterval = const Duration(milliseconds: 50),
-      this.tileFadeInDuration = const Duration(milliseconds: 200),
+      this.tileFadeInDuration = const Duration(milliseconds: 100),
       rebuild})
       : assert(tileFadeInDuration != null && !tileFadeInDuration.isNegative),
         assert(updateInterval != null && !updateInterval.isNegative),
@@ -352,7 +352,7 @@ class _TileLayerState extends State<TileLayer> {
 
     final Widget content = AnimatedOpacity(
       key: Key(tile.coordsKey),
-      opacity: tile.active || tile.fadeStarted ? 1.0 : 0.0,
+      opacity: tile.fadeStarted ? 1.0 : 0.0,
       duration: options.tileFadeInDuration,
       onEnd: tile.onAnimateEnd,
       child: RawImage(
@@ -361,7 +361,9 @@ class _TileLayerState extends State<TileLayer> {
       ),
     );
 
-    tile.fadeStarted = true;
+    if (null != tile.imageInfo) {
+      tile.fadeStarted = true;
+    }
 
     return Positioned(
       key: Key(tile.coordsKey),

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -272,7 +272,7 @@ class _TileLayerState extends State<TileLayer> {
     _throttleUpdate = widget.options.updateInterval == 0
         ? null
         : (PublishSubject<void>()
-          ..throttleTime(Duration(milliseconds: 50))
+          ..throttleTime(Duration(milliseconds: widget.options.updateInterval))
           ..listen((_) => _update(null)));
   }
 
@@ -422,7 +422,7 @@ class _TileLayerState extends State<TileLayer> {
       var lvl = entry.value;
 
       if (z == zoom || _hasLevelChildren(z)) {
-        lvl.zIndex = maxZoom = (zoom - z).abs();
+        lvl.zIndex = maxZoom - (zoom - z).abs();
       } else {
         toRemove.add(z);
       }

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -963,9 +963,14 @@ class Tile implements Comparable<Tile> {
     this.retain = false,
     this.loadError = false,
   }) {
-    _imageStream = imageProvider.resolve(ImageConfiguration());
-    _listener = ImageStreamListener(_tileOnLoad, onError: _tileOnError);
-    _imageStream.addListener(_listener);
+    try {
+      _imageStream = imageProvider.resolve(ImageConfiguration());
+      _listener = ImageStreamListener(_tileOnLoad, onError: _tileOnError);
+      _imageStream.addListener(_listener);
+    } catch (e, s) {
+      // make sure all exception is handled - #444
+      _tileOnError(e, s);
+    }
   }
 
   // call this before GC!

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -460,10 +460,6 @@ class _TileLayerState extends State<TileLayer> {
       // TODO: remove diagnostic
       print('_removeAllTiles');
 
-      // TODO: this is fair enough
-      // however if MapOptions has the same maxZoom as this TileLayer then
-      // this shouldn't happen (fix at MapOptions! -- double tap ok but two finger scale need some fix)
-      // TODO: MapOptions need minZoom too
       _removeAllTiles();
       return;
     }
@@ -598,14 +594,10 @@ class _TileLayerState extends State<TileLayer> {
     var tileZoom = _clampZoom(zoom.roundToDouble());
     if ((options.maxZoom != null && tileZoom > options.maxZoom) ||
         (options.minZoom != null && tileZoom < options.minZoom)) {
-      // TODO: this is fair enough
-      // however if MapOptions has the same maxZoom as this TileLayer then
-      // this shouldn't happen (fix at MapOptions! -- double tap ok but two finger scale need some fix)
-      // TODO: MapOptions need minZoom too
-      tileZoom = null;
-
       // TODO: remove diagnostic
       print('Zoom become null');
+
+      tileZoom = null;
     }
 
     _tileZoom = tileZoom;

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -16,20 +16,34 @@ abstract class TileProvider {
   void dispose() {}
 
   String getTileUrl(Coords coords, TileLayerOptions options) {
-    if (options.wmsOptions != null)
+    if (options.wmsOptions != null) {
       return options.wmsOptions.getUrl(coords, options.tileSize.toInt());
+    }
+
+    var z = _getZoomForUrl(coords, options);
+
     var data = <String, String>{
       'x': coords.x.round().toString(),
       'y': coords.y.round().toString(),
-      'z': coords.z.round().toString(),
+      'z': z.round().toString(),
       's': getSubdomain(coords, options)
     };
     if (options.tms) {
-      data['y'] = invertY(coords.y.round(), coords.z.round()).toString();
+      data['y'] = invertY(coords.y.round(), z.round()).toString();
     }
     var allOpts = Map<String, String>.from(data)
       ..addAll(options.additionalOptions);
     return util.template(options.urlTemplate, allOpts);
+  }
+
+  double _getZoomForUrl(Coords coords, TileLayerOptions options) {
+    var zoom = coords.z;
+
+    if (options.zoomReverse) {
+      zoom = options.maxZoom - zoom;
+    }
+
+    return zoom += options.zoomOffset;
   }
 
   int invertY(int y, int z) {

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -1,13 +1,12 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/core/center_zoom.dart';
 import 'package:flutter_map/src/core/point.dart';
 import 'package:latlong/latlong.dart';
-
-import 'package:flutter/material.dart';
 
 class MapControllerImpl implements MapController {
   final Completer<Null> _readyCompleter = Completer<Null>();
@@ -109,7 +108,7 @@ class MapState {
   }
 
   void move(LatLng center, double zoom, {hasGesture = false}) {
-    zoom = _fitZoomToBounds(zoom);
+    zoom = fitZoomToBounds(zoom);
     final mapMoved = center != _lastCenter || zoom != _zoom;
 
     if (_lastCenter != null &&
@@ -135,7 +134,7 @@ class MapState {
     }
   }
 
-  double _fitZoomToBounds(double zoom) {
+  double fitZoomToBounds(double zoom) {
     zoom ??= _zoom;
     // Abide to min/max zoom
     if (options.maxZoom != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   path_provider: ^1.5.1
   vector_math: ^2.0.0
   proj4dart: ^1.0.4
+  rxdart: ^0.23.1
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   path_provider: ^1.5.1
   vector_math: ^2.0.0
   proj4dart: ^1.0.4
-  rxdart: ^0.23.1
 
 dev_dependencies:
   pedantic: ^1.8.0


### PR DESCRIPTION
Hello, I made some changes mainly in [tile_layer.dart](/johnpryan/flutter_map/blob/master/lib/src/layer/tile_layer.dart) in order to keep the old tiles on the screen when zooming if new ones not avaible. These changes based on current Leaflet's tile fetching /retaining strategy see [TileLayer.js](https://github.com/Leaflet/Leaflet/blob/master/src/layer/tile/TileLayer.js) / [GridLayer.js](https://github.com/Leaflet/Leaflet/blob/master/src/layer/tile/GridLayer.js).

I also added some missing features like minZoom / minNativeZoom / maxNativeZoom / zoomReverse / zoomOffset / errorImage and fixed / tracked down some other problems which I will mention in closes section.

Normal use case (fast internet connection)
![normal use](https://user-images.githubusercontent.com/8436039/78462759-6900e780-76d5-11ea-9aaf-3ac68de67623.gif)

Simulating slow internet connection
![slow internet2](https://user-images.githubusercontent.com/8436039/78462366-8b910180-76d1-11ea-9700-8514adbc7d0c.gif)

Add support for Error tiles
![error image](https://user-images.githubusercontent.com/8436039/78462380-b4b19200-76d1-11ea-8de9-99448f7c35b3.gif)

Add support for minNativeZoom / maxNativeZoom (this demo shows locked minNativeZoom: 16 while real zoom is about 12/10 <- it will be a real trial for mobile phones bandwidth / render time)
![minNativeZoom test1](https://user-images.githubusercontent.com/8436039/78462444-43beaa00-76d2-11ea-9dfa-dfe54de91dbd.gif)

Support for remove tiles if we are out of zoom limits (we don't call any setState if we are out of bounds, however we pay attention for zoom lvl changes) -- this can happen if forinstance MapOptions has maxZoom: 18, but TileLayerOptions has maxZoom: 16; works with minZoom too, and fixed #59 overscale problems (helps if MapOptions / TileLayerOptions has same maxZoom, however without this fix overscale could go beyond limits which could have caused remove all tiles).
![remove tiles when out of zoom bounds](https://user-images.githubusercontent.com/8436039/78462501-fe4eac80-76d2-11ea-8eb0-1f27cfccfcbb.gif)

closes #59
closes #79
closes #125
closes #227 (we don't need remove maxZoom because we may have multiple layers and if current tilelayer is more than maxZoom then _removeAllTiles called also applies to minZoom; we stop fetching new tiles when not inside min /maxZoom moreover we skip setState calls for performance reasons)
closes #339 (performance -- maybe this PR resolves this because build() method was designed to run as fast as possible (_update is [throttled](https://github.com/Leaflet/Leaflet/blob/master/src/layer/tile/GridLayer.js#L248) and _pruneTiles / _setView called only when necessary))
closes #386 
closes #429
closes #444
closes #457
closes #463
closes #492 (performance -- maybe this PR resolves this because build() method was designed to run as fast as possible (_update is [throttled](https://github.com/Leaflet/Leaflet/blob/master/src/layer/tile/GridLayer.js#L248) and _pruneTiles / _setView called only when necessary))
closes #517
closes #523
closes #536
closes #538

PR will be closed also:
closes #525
closes #570

PR also gives opportunity to finish these issues easily (we can add some callbacks to TileLayerOptions - when a Tile is downloaded / become active (when loaded + and fade ends) / Tile loads with an error / or when all tiles loaded (_noTilesToLoad internal function can fire callback when the grid layer loaded all visible tiles)):
see #345
see #377