### PR TITLE
fix Flickering bug - on double click / MapController move

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -604,8 +604,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
     }
 
     _pruneTiles();
-
-    _setZoomTransforms(center, zoom);
   }
 
   void _setZoomTransforms(LatLng center, double zoom) {
@@ -665,12 +663,14 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
     if (_tileZoom == null) {
       // if there is no _tileZoom available it means we are out within zoom level
-      // we will restory fully via _setView call if we are back on trail
+      // we will restore fully via _setView call if we are back on trail
       if ((options.maxZoom != null && tileZoom <= options.maxZoom) &&
           (options.minZoom != null && tileZoom >= options.minZoom)) {
         _tileZoom = tileZoom;
         setState(() {
           _setView(map.center, tileZoom);
+
+          _setZoomTransforms(map.center, map.zoom);
         });
       }
     } else {
@@ -678,6 +678,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         if ((tileZoom - _tileZoom).abs() >= 1) {
           // It was a zoom lvl change
           _setView(map.center, tileZoom);
+
+          _setZoomTransforms(map.center, map.zoom);
         } else {
           if (null == _throttleUpdate) {
             _update(null);


### PR DESCRIPTION
Hi, this PR resolves #578 `Flicker on double click zoom` issue which was introduced by #572.

Flicker gif:
![flick bug3](https://user-images.githubusercontent.com/8436039/78821079-30b12000-79d9-11ea-9a56-4e34fcb933a1.gif)

Patch gif:
![flick bug - fix](https://user-images.githubusercontent.com/8436039/78821093-39a1f180-79d9-11ea-9f75-537181c1fc79.gif)
