### PR TITLE
Observe TileLayerOptions changes

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -884,6 +884,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       print(error);
 
       tile.loadError = true;
+    } else {
+      tile.loadError = false;
     }
 
     var key = _tileCoordsToKey(coords);


### PR DESCRIPTION
Hello, this PR adds support for detecting URL changes / tileSize changes / updateInterval changes and reloads Tiles if necessary.

![change layer](https://user-images.githubusercontent.com/8436039/79050585-46b61f00-7c2b-11ea-855d-bb3ad3582c6f.gif)

closes #583