### PR TITLE
Support retina mode

### DIFF
--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -18,6 +18,10 @@ import 'layer.dart';
 /// A tile is an image binded to a specific geographical position.
 class TileLayerOptions extends LayerOptions {
   /// Defines the structure to create the URLs for the tiles.
+  /// `{s}` means one of the available subdomains (can be omitted)
+  /// `{z}` zoom level
+  /// `{x}` and `{y}` — tile coordinates
+  /// `{r}` can be used to add "&commat;2x" to the URL to load retina tiles (can be omitted)
   ///
   /// Example:
   ///
@@ -132,7 +136,7 @@ class TileLayerOptions extends LayerOptions {
   ///
   /// TileLayerOptions(
   ///     urlTemplate: "https://api.tiles.mapbox.com/v4/"
-  ///                  "{id}/{z}/{x}/{y}@2x.png?access_token={accessToken}",
+  ///                  "{id}/{z}/{x}/{y}{r}.png?access_token={accessToken}",
   ///     additionalOptions: {
   ///         'accessToken': '<PUT_ACCESS_TOKEN_HERE>',
   ///          'id': 'mapbox.streets',
@@ -155,6 +159,12 @@ class TileLayerOptions extends LayerOptions {
 
   /// If `true`, it will request four tiles of half the specified size and a
   /// bigger zoom level in place of one to utilize the high resolution.
+  ///
+  /// If `true` then MapOptions's `maxZoom` should be `maxZoom - 1` since retinaMode
+  /// just simulates retina display by playing with `zoomOffset`.
+  /// If geoserver supports retina `@2` tiles then it it advised to use them
+  /// instead of simulating it (use {r} in the [urlTemplate])
+  ///
   /// It is advised to use retinaMode if display supports it, write code like this:
   /// TileLayerOptions(
   ///     retinaMode: true && MediaQuery.of(context).devicePixelRatio > 1.0,

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -28,7 +28,7 @@ abstract class TileProvider {
       'y': coords.y.round().toString(),
       'z': z.round().toString(),
       's': getSubdomain(coords, options),
-      // 'r': options.retinaMode ? '@2x' : '',
+      'r': '@2x',
     };
     if (options.tms) {
       data['y'] = invertY(coords.y.round(), z.round()).toString();

--- a/lib/src/layer/tile_provider/tile_provider.dart
+++ b/lib/src/layer/tile_provider/tile_provider.dart
@@ -17,7 +17,8 @@ abstract class TileProvider {
 
   String getTileUrl(Coords coords, TileLayerOptions options) {
     if (options.wmsOptions != null) {
-      return options.wmsOptions.getUrl(coords, options.tileSize.toInt());
+      return options.wmsOptions
+          .getUrl(coords, options.tileSize.toInt(), options.retinaMode);
     }
 
     var z = _getZoomForUrl(coords, options);
@@ -26,7 +27,8 @@ abstract class TileProvider {
       'x': coords.x.round().toString(),
       'y': coords.y.round().toString(),
       'z': z.round().toString(),
-      's': getSubdomain(coords, options)
+      's': getSubdomain(coords, options),
+      // 'r': options.retinaMode ? '@2x' : '',
     };
     if (options.tms) {
       data['y'] = invertY(coords.y.round(), z.round()).toString();


### PR DESCRIPTION
Hello, I made some changes to support simulating retina mode (_note: If geoserver supports retina `@2` tiles then it it advised to use them instead of simulating_).

It won't detect if device supports retina because I don't want force user to use `Material app` because of `MediaQuery.of(context)`.

However it is documented how to use it:
```
  /// If `true`, it will request four tiles of half the specified size and a
  /// bigger zoom level in place of one to utilize the high resolution.
  ///
  /// If `true` then MapOptions's `maxZoom` should be `maxZoom - 1` since retinaMode
  /// just simulates retina display by playing with `zoomOffset`.
  /// If geoserver supports retina `@2` tiles then it it advised to use them
  /// instead of simulating it (use {r} in the [urlTemplate])
  ///
  /// It is advised to use retinaMode if display supports it, write code like this:
  /// TileLayerOptions(
  ///     retinaMode: true && MediaQuery.of(context).devicePixelRatio > 1.0,
  /// ),
  final bool retinaMode;

```
Moreover if retina is enabled then `MapOptions`'s  `maxZoom` should be `maxZoom - 1`, currently `MapState` doesn't detect any `maxZoom` based on Layers like Leaflet _(If not specified and at least one `GridLayer` or `TileLayer` is in the map, the highest of their `maxZoom` options will be used instead.)_.

![retina](https://user-images.githubusercontent.com/8436039/79146288-73506f00-7dc2-11ea-9193-ee944e46295b.gif)

Note: this PR needs #584 so merge this only when it is accepted.

closes #212