### PR TITLE
Fix deprecation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_image: ^3.0.0
   cached_network_image: ^2.0.0
   sqflite: ^1.1.5
-  path_provider: ^1.5.1
+  path_provider: ^1.6.7
   vector_math: ^2.0.0
   proj4dart: ^1.0.4
   meta: ^1.1.0


### PR DESCRIPTION
This fixes the warning:
```
[deprecation] getFlutterEngine() in FlutterPluginBinding has been deprecated
            binding.getFlutterEngine().getDartExecutor(), "plugins.flutter.io/path_provider");
```