### PR TITLE
Handle exception on move without internet connection

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,6 +18,7 @@ import './pages/plugin_zoombuttons.dart';
 import './pages/polyline.dart';
 import './pages/tap_to_add.dart';
 import './pages/wms_tile_layer.dart';
+import './pages/tile_loading_error_handle.dart';
 
 void main() => runApp(MyApp());
 
@@ -50,6 +51,7 @@ class MyApp extends StatelessWidget {
         OverlayImagePage.route: (context) => OverlayImagePage(),
         WMSLayerPage.route: (context) => WMSLayerPage(),
         CustomCrsPage.route: (context) => CustomCrsPage(),
+        TileLoadingErrorHandle.route: (context) => TileLoadingErrorHandle(),
       },
     );
   }

--- a/example/lib/pages/tile_loading_error_handle.dart
+++ b/example/lib/pages/tile_loading_error_handle.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong/latlong.dart';
+
+import '../widgets/drawer.dart';
+
+class TileLoadingErrorHandle extends StatefulWidget {
+  static const String route = '/tile_loading_error_handle';
+
+  @override
+  _TileLoadingErrorHandleState createState() => _TileLoadingErrorHandleState();
+}
+
+class _TileLoadingErrorHandleState extends State<TileLoadingErrorHandle> {
+  @override
+  Widget build(BuildContext context) {
+    bool _needLoadingError = true;
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Tile Loading Error Handle')),
+      drawer: buildDrawer(context, TileLoadingErrorHandle.route),
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+              child: Text('Turn on Airplane mode and try to move or zoom map'),
+            ),
+            Flexible(
+              child: Builder(builder: (BuildContext context) {
+                return FlutterMap(
+                  mapController: MapController(),
+                  options: MapOptions(
+                    center: LatLng(51.5, -0.09),
+                    zoom: 5.0,
+                    onPositionChanged: (MapPosition mapPosition, bool _) {
+                      print('++++++++++++++++++++++++++++++++++');
+                      _needLoadingError = true;
+                    },
+                  ),
+                  layers: [
+                    TileLayerOptions(
+                      urlTemplate:
+                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      subdomains: ['a', 'b', 'c'],
+                      // For example purposes. It is recommended to use
+                      // TileProvider with a caching and retry strategy, like
+                      // NetworkTileProvider or CachedNetworkTileProvider
+                      tileProvider: NonCachingNetworkTileProvider(),
+                      errorTileCallback: (Tile tile, error) {
+                        if (_needLoadingError) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            Scaffold.of(context).showSnackBar(SnackBar(
+                              duration: Duration(seconds: 1),
+                              content: Text(
+                                error.toString(),
+                                style: TextStyle(color: Colors.black),
+                              ),
+                              backgroundColor: Colors.deepOrange,
+                            ));
+                          });
+                          _needLoadingError = false;
+                        }
+                      },
+                    ),
+                  ],
+                );
+              }),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/pages/tile_loading_error_handle.dart
+++ b/example/lib/pages/tile_loading_error_handle.dart
@@ -30,7 +30,6 @@ class _TileLoadingErrorHandleState extends State<TileLoadingErrorHandle> {
             Flexible(
               child: Builder(builder: (BuildContext context) {
                 return FlutterMap(
-                  mapController: MapController(),
                   options: MapOptions(
                     center: LatLng(51.5, -0.09),
                     zoom: 5.0,

--- a/example/lib/pages/tile_loading_error_handle.dart
+++ b/example/lib/pages/tile_loading_error_handle.dart
@@ -35,7 +35,6 @@ class _TileLoadingErrorHandleState extends State<TileLoadingErrorHandle> {
                     center: LatLng(51.5, -0.09),
                     zoom: 5.0,
                     onPositionChanged: (MapPosition mapPosition, bool _) {
-                      print('++++++++++++++++++++++++++++++++++');
                       _needLoadingError = true;
                     },
                   ),

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -18,6 +18,7 @@ import '../pages/plugin_zoombuttons.dart';
 import '../pages/polyline.dart';
 import '../pages/tap_to_add.dart';
 import '../pages/wms_tile_layer.dart';
+import '../pages/tile_loading_error_handle.dart';
 
 Drawer buildDrawer(BuildContext context, String currentRoute) {
   return Drawer(
@@ -154,6 +155,13 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           selected: currentRoute == OverlayImagePage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, OverlayImagePage.route);
+          },
+        ),
+        ListTile(
+          title: const Text('Tile loading error handle'),
+          selected: currentRoute == OverlayImagePage.route,
+          onTap: () {
+            Navigator.pushReplacementNamed(context, TileLoadingErrorHandle.route);
           },
         ),
       ],

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -159,7 +159,7 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
         ),
         ListTile(
           title: const Text('Tile loading error handle'),
-          selected: currentRoute == OverlayImagePage.route,
+          selected: currentRoute == TileLoadingErrorHandle.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, TileLoadingErrorHandle.route);
           },

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -186,8 +186,8 @@ class TileLayerOptions extends LayerOptions {
       // Tiles fade in duration in milliseconds (default 100),
       // it can 0 to avoid fade in
       int tileFadeInDuration = 100,
-      rebuild,
-      this.errorTileCallback,})
+      this.errorTileCallback,
+      rebuild,})
       : updateInterval =
             updateInterval <= 0 ? null : Duration(milliseconds: updateInterval),
         tileFadeInDuration = tileFadeInDuration <= 0

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -13,6 +13,8 @@ import 'package:tuple/tuple.dart';
 
 import 'layer.dart';
 
+typedef ErrorTileCallBack = void Function(Tile tile, dynamic error);
+
 /// Describes the needed properties to create a tile-based layer.
 /// A tile is an image binded to a specific geographical position.
 class TileLayerOptions extends LayerOptions {
@@ -152,6 +154,9 @@ class TileLayerOptions extends LayerOptions {
   // it can 0 to avoid fade in
   final Duration tileFadeInDuration;
 
+  /// This callback will be execute if some errors by getting tile
+  final ErrorTileCallBack errorTileCallback;
+
   TileLayerOptions(
       {this.urlTemplate,
       this.tileSize = 256.0,
@@ -181,7 +186,8 @@ class TileLayerOptions extends LayerOptions {
       // Tiles fade in duration in milliseconds (default 100),
       // it can 0 to avoid fade in
       int tileFadeInDuration = 100,
-      rebuild})
+      rebuild,
+      this.errorTileCallback,})
       : updateInterval =
             updateInterval <= 0 ? null : Duration(milliseconds: updateInterval),
         tileFadeInDuration = tileFadeInDuration <= 0
@@ -822,6 +828,10 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
       print(error);
 
       tile.loadError = true;
+
+      if (options.errorTileCallback != null) {
+        options.errorTileCallback(tile, error);
+      }
     }
 
     var key = _tileCoordsToKey(coords);


### PR DESCRIPTION
Hi **flutter_map** team!

Here is desigion for issue #593 

- add errorTileCallback for handling errors while no tiles
- example how to use errorTileCallback

Main goal to catch this exception, is to notify user about internet connection lost.