### PR TITLE
Add flutter_map_marker_popup to plugins in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Note that there is also `FileTileProvider()`, which you can use to load tiles fr
 - [flutter_map_marker_cluster](https://github.com/lpongetti/flutter_map_marker_cluster): Provides Beautiful Animated Marker Clustering functionality
 - [user_location](https://github.com/igaurab/user_location_plugin): A plugin to handle and plot the current user location in FlutterMap
 - [flutter_map_tappable_polyline](https://github.com/OwnWeb/flutter_map_tappable_polyline): A plugin to add `onTap` callback to `Polyline`
+- [flutter_map_marker_popup](https://github.com/rorystephenson/flutter_map_marker_popup): A plugin to show customisable popups for markers.
 
 ## Roadmap
 


### PR DESCRIPTION
I noticed there are a lot of requests for how to add popups and having tried the suggested approaches myself I found there were some drawbacks including:

 * The popup disappears once the marker disappears even though the popup is big enough to still be visible.
 * The popup is not tappable.
 * A fixed size was required for the popup.
 * It was not easy to choose how it is positioned.

So I wrote my own code to handle this which I've since moved to a plugin:

https://github.com/rorystephenson/flutter_map_marker_popup