### PR TITLE
Polyline culling

### DIFF
--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -11,9 +11,17 @@ class PolygonLayerOptions extends LayerOptions {
   final bool polygonCulling;
 
   /// screen space culling of polygons based on bounding box
-  PolygonLayerOptions(
-      {this.polygons = const [], this.polygonCulling = false, rebuild})
-      : super(rebuild: rebuild);
+  PolygonLayerOptions({
+    this.polygons = const [],
+    this.polygonCulling = false,
+    rebuild,
+  }) : super(rebuild: rebuild) {
+    if (polygonCulling) {
+      for (var polygon in polygons) {
+        polygon.boundingBox = LatLngBounds.fromPoints(polygon.points);
+      }
+    }
+  }
 }
 
 class Polygon {
@@ -36,11 +44,9 @@ class Polygon {
     this.borderColor = const Color(0xFFFFFF00),
     this.disableHolesBorder = false,
     this.isDotted = false,
-  }) : holeOffsetsList = null == holePointsList
+  }) : holeOffsetsList = null == holePointsList || holePointsList.isEmpty
             ? null
-            : List.generate(holePointsList.length, (_) => []) {
-    boundingBox = LatLngBounds.fromPoints(points);
-  }
+            : List.generate(holePointsList.length, (_) => []);
 }
 
 class PolygonLayer extends StatelessWidget {
@@ -141,11 +147,9 @@ class PolygonPainter extends CustomPainter {
     if (polygonOpt.borderStrokeWidth > 0.0) {
       var borderRadius = (polygonOpt.borderStrokeWidth / 2);
 
-      final borderPaint = polygonOpt.borderStrokeWidth > 0.0
-          ? (Paint()
-            ..color = polygonOpt.borderColor
-            ..strokeWidth = polygonOpt.borderStrokeWidth)
-          : null;
+      final borderPaint = Paint()
+        ..color = polygonOpt.borderColor
+        ..strokeWidth = polygonOpt.borderStrokeWidth;
 
       if (polygonOpt.isDotted) {
         var spacing = polygonOpt.borderStrokeWidth * 1.5;


### PR DESCRIPTION
Added Polyline culling based on screen bounds. (This PR is the polyline version of #449)

If you set `polylineCulling` to `true` on `PolylineLayerOptions` then any polylines outside of the screen’s bounds won't be drawn, therefore, saving rendering time and improving performance when displaying a large set of polylines.

I also updated `PolygonLayerOptions` to calculate boundingBox only when necessary.

closes #610