### PR TITLE
feat(*): widget layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,55 @@ Widget build(BuildContext context) {
 }
 ```
 
+### Widget Layers
+
+__Use the new way to create layers__ (compatible with previous version)
+
+```dart
+Widget build(BuildContext context) {
+  return FlutterMap(
+    options: MapOptions(
+      center: LatLng(51.5, -0.09),
+      zoom: 13.0,
+    ),
+    layers: [
+      MarkerLayerOptions(
+        markers: [
+          Marker(
+            width: 80.0,
+            height: 80.0,
+            point: LatLng(51.5, -0.09),
+            builder: (ctx) =>
+            Container(
+              child: FlutterLogo(),
+            ),
+          ),
+        ],
+      ),
+    ]
+    children: <Widget>[
+      TileLayerWidget(options: TileLayerOptions(
+        urlTemplate: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        subdomains: ['a', 'b', 'c']
+      )),
+      MarkerLayerWidget(options: MarkerLayerOptions(
+        markers: [
+          Marker(
+            width: 80.0,
+            height: 80.0,
+            point: LatLng(51.5, -0.09),
+            builder: (ctx) =>
+            Container(
+              child: FlutterLogo(),
+            ),
+          ),
+        ],
+      )),
+    ],
+  );
+}
+```
+
 ### Custom CRS
 
 By default flutter_map supports only WGS84 (EPSG:4326) and Google Mercator (EPSG:3857) projections. With the integration of [proj4dart](https://github.com/maRci002/proj4dart) any coordinate reference systems (CRS) can be defined and used.

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true
 android.enableR8=true

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,6 +17,7 @@ import './pages/plugin_scalebar.dart';
 import './pages/plugin_zoombuttons.dart';
 import './pages/polyline.dart';
 import './pages/tap_to_add.dart';
+import './pages/widgets.dart';
 import './pages/wms_tile_layer.dart';
 
 void main() => runApp(MyApp());
@@ -32,6 +33,7 @@ class MyApp extends StatelessWidget {
       ),
       home: HomePage(),
       routes: <String, WidgetBuilder>{
+        WidgetsPage.route: (context) => WidgetsPage(),
         TapToAddPage.route: (context) => TapToAddPage(),
         EsriPage.route: (context) => EsriPage(),
         PolylinePage.route: (context) => PolylinePage(),

--- a/example/lib/pages/widgets.dart
+++ b/example/lib/pages/widgets.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/plugin_api.dart';
+import 'package:latlong/latlong.dart';
+
+import '../pages/zoombuttons_plugin_option.dart';
+import '../widgets/drawer.dart';
+
+class WidgetsPage extends StatelessWidget {
+  static const String route = 'widgets';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Widgets')),
+      drawer: buildDrawer(context, WidgetsPage.route),
+      body: Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            Flexible(
+              child: FlutterMap(
+                options: MapOptions(
+                  center: LatLng(51.5, -0.09),
+                  zoom: 5.0,
+                  plugins: [
+                    ZoomButtonsPlugin(),
+                  ],
+                ),
+                layers: [
+                  ZoomButtonsPluginOption(
+                    minZoom: 4,
+                    maxZoom: 19,
+                    mini: true,
+                    padding: 10,
+                    alignment: Alignment.bottomLeft,
+                  )
+                ],
+                children: <Widget>[
+                  TileLayerWidget(
+                    options: TileLayerOptions(
+                      urlTemplate:
+                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                      subdomains: ['a', 'b', 'c'],
+                    ),
+                  ),
+                  MovingWithoutRefreshAllMapMarkers(),
+                  Text(
+                    'Plugin is just Text widget',
+                    style: TextStyle(
+                        fontSize: 22,
+                        color: Colors.red,
+                        fontWeight: FontWeight.bold,
+                        backgroundColor: Colors.yellow),
+                  )
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MovingWithoutRefreshAllMapMarkers extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() =>
+      _MovingWithoutRefreshAllMapMarkersState();
+}
+
+class _MovingWithoutRefreshAllMapMarkersState
+    extends State<MovingWithoutRefreshAllMapMarkers> {
+  Marker _marker;
+  Timer _timer;
+  int _markerIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _marker = _markers[_markerIndex];
+    _timer = Timer.periodic(Duration(seconds: 1), (_) {
+      setState(() {
+        _marker = _markers[_markerIndex];
+        _markerIndex = (_markerIndex + 1) % _markers.length;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MarkerLayerWidget(
+      options: MarkerLayerOptions(markers: <Marker>[_marker]),
+    );
+  }
+}
+
+List<Marker> _markers = [
+  Marker(
+    width: 80.0,
+    height: 80.0,
+    point: LatLng(51.5, -0.09),
+    builder: (ctx) => Container(
+      child: FlutterLogo(),
+    ),
+  ),
+  Marker(
+    width: 80.0,
+    height: 80.0,
+    point: LatLng(53.3498, -6.2603),
+    builder: (ctx) => Container(
+      child: FlutterLogo(),
+    ),
+  ),
+  Marker(
+    width: 80.0,
+    height: 80.0,
+    point: LatLng(48.8566, 2.3522),
+    builder: (ctx) => Container(
+      child: FlutterLogo(),
+    ),
+  ),
+];

--- a/example/lib/widgets/drawer.dart
+++ b/example/lib/widgets/drawer.dart
@@ -17,6 +17,7 @@ import '../pages/plugin_scalebar.dart';
 import '../pages/plugin_zoombuttons.dart';
 import '../pages/polyline.dart';
 import '../pages/tap_to_add.dart';
+import '../pages/widgets.dart';
 import '../pages/wms_tile_layer.dart';
 
 Drawer buildDrawer(BuildContext context, String currentRoute) {
@@ -33,6 +34,13 @@ Drawer buildDrawer(BuildContext context, String currentRoute) {
           selected: currentRoute == HomePage.route,
           onTap: () {
             Navigator.pushReplacementNamed(context, HomePage.route);
+          },
+        ),
+        ListTile(
+          title: const Text('Widgets'),
+          selected: currentRoute == WidgetsPage.route,
+          onTap: () {
+            Navigator.pushReplacementNamed(context, WidgetsPage.route);
           },
         ),
         ListTile(

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -37,6 +37,9 @@ class FlutterMap extends StatefulWidget {
   /// [PolylineLayerOptions].
   final List<LayerOptions> layers;
 
+  /// A set of layers' widgets to used to create the layers on the map.
+  final List<Widget> children;
+
   /// [MapOptions] to create a [MapState] with.
   ///
   /// This property must not be null.
@@ -48,7 +51,8 @@ class FlutterMap extends StatefulWidget {
   FlutterMap({
     Key key,
     @required this.options,
-    this.layers,
+    this.layers = const [],
+    this.children = const [],
     MapController mapController,
   })  : _mapController = mapController ?? MapController(),
         super(key: key);

--- a/lib/src/layer/circle_layer.dart
+++ b/lib/src/layer/circle_layer.dart
@@ -30,6 +30,19 @@ class CircleMarker {
   });
 }
 
+class CircleLayerWidget extends StatelessWidget {
+  final CircleLayerOptions options;
+
+  CircleLayerWidget({@required this.options});
+  
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+    return CircleLayer(options, mapState, mapState.onMoved);
+  }
+}
+
+
 class CircleLayer extends StatelessWidget {
   final CircleLayerOptions circleOpts;
   final MapState map;

--- a/lib/src/layer/group_layer.dart
+++ b/lib/src/layer/group_layer.dart
@@ -9,6 +9,19 @@ class GroupLayerOptions extends LayerOptions {
   GroupLayerOptions({this.group});
 }
 
+class GroupLayerWidget extends StatelessWidget {
+  final GroupLayerOptions options;
+
+  GroupLayerWidget({@required this.options});
+  
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+    return GroupLayer(options, mapState, mapState.onMoved);
+  }
+}
+
+
 class GroupLayer extends StatelessWidget {
   final GroupLayerOptions groupOpts;
   final MapState map;

--- a/lib/src/layer/marker_layer.dart
+++ b/lib/src/layer/marker_layer.dart
@@ -87,6 +87,18 @@ class Marker {
   }) : anchor = Anchor.forPos(anchorPos, width, height);
 }
 
+class MarkerLayerWidget extends StatelessWidget {
+  final MarkerLayerOptions options;
+
+  MarkerLayerWidget({@required this.options});
+  
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+    return MarkerLayer(options, mapState, mapState.onMoved);
+  }
+}
+
 class MarkerLayer extends StatelessWidget {
   final MarkerLayerOptions markerOpts;
   final MapState map;

--- a/lib/src/layer/overlay_image_layer.dart
+++ b/lib/src/layer/overlay_image_layer.dart
@@ -26,6 +26,18 @@ class OverlayImage {
   });
 }
 
+class OverlayImageLayerWidget extends StatelessWidget {
+  final OverlayImageLayerOptions options;
+
+  OverlayImageLayerWidget({@required this.options});
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+    return OverlayImageLayer(options, mapState, mapState.onMoved);
+  }
+}
+
 class OverlayImageLayer extends StatelessWidget {
   final OverlayImageLayerOptions overlayImageOpts;
   final MapState map;

--- a/lib/src/layer/polygon_layer.dart
+++ b/lib/src/layer/polygon_layer.dart
@@ -49,6 +49,17 @@ class Polygon {
             : List.generate(holePointsList.length, (_) => []);
 }
 
+class PolygonLayerWidget extends StatelessWidget {
+  final PolygonLayerOptions options;
+  PolygonLayerWidget({@required this.options});
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+    return PolygonLayer(options, mapState, mapState.onMoved);
+  }
+}
+
 class PolygonLayer extends StatelessWidget {
   final PolygonLayerOptions polygonOpts;
   final MapState map;

--- a/lib/src/layer/polyline_layer.dart
+++ b/lib/src/layer/polyline_layer.dart
@@ -47,6 +47,17 @@ class Polyline {
   });
 }
 
+class PolylineLayerWidget extends StatelessWidget {
+  final PolylineLayerOptions options;
+  PolylineLayerWidget({@required this.options});
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+    return PolylineLayer(options, mapState, mapState.onMoved);
+  }
+}
+
 class PolylineLayer extends StatelessWidget {
   final PolylineLayerOptions polylineOpts;
   final MapState map;

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -274,6 +274,28 @@ class WMSTileLayerOptions {
   }
 }
 
+class TileLayerWidget extends StatefulWidget {
+  final TileLayerOptions options;
+
+  TileLayerWidget({@required this.options});
+
+  @override
+  State<StatefulWidget> createState() => _TileLayerWidgetState();
+}
+
+class _TileLayerWidgetState extends State<TileLayerWidget> {
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+
+    return TileLayer(
+      mapState: mapState,
+      stream: mapState.onMoved,
+      options: widget.options,
+    );
+  }
+}
+
 class TileLayer extends StatefulWidget {
   final TileLayerOptions options;
   final MapState mapState;
@@ -310,8 +332,6 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
 
   @override
   void initState() {
-    super.initState();
-
     _tileSize = CustomPoint(options.tileSize, options.tileSize);
     _resetView();
     _update(null);
@@ -327,16 +347,18 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
         ),
       )..listen(_update);
     }
+
+    super.initState();
   }
 
   @override
   void dispose() {
-    super.dispose();
-
     _removeAllTiles();
     _moveSub?.cancel();
     options.tileProvider.dispose();
     _throttleUpdate?.close();
+
+    super.dispose();
   }
 
   @override

--- a/lib/src/map/flutter_map_state.dart
+++ b/lib/src/map/flutter_map_state.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
@@ -7,6 +8,7 @@ import 'package:flutter_map/src/gestures/gestures.dart';
 import 'package:flutter_map/src/layer/group_layer.dart';
 import 'package:flutter_map/src/layer/overlay_image_layer.dart';
 import 'package:flutter_map/src/map/map.dart';
+import 'package:flutter_map/src/map/map_state_widget.dart';
 import 'package:latlong/latlong.dart';
 import 'package:positioned_tap_detector/positioned_tap_detector.dart';
 import 'package:async/async.dart';
@@ -96,8 +98,9 @@ class FlutterMapState extends MapGestureMixin {
 
       var layerStack = Stack(
         children: [
-          for (final layer in widget.layers)
-            _createLayer(layer, widget.options.plugins)
+          ...widget.children ?? [],
+          ...widget.layers
+              .map((layer) => _createLayer(layer, widget.options.plugins)) ?? [],
         ],
       );
 
@@ -128,20 +131,26 @@ class FlutterMapState extends MapGestureMixin {
         // By using an OverflowBox with the enlarged drawing area all the layers
         // act as if the area really would be that big. So no changes in any layer
         // logic is necessary for the rotation
-        return ClipRect(
-          child: Transform.rotate(
-            angle: angle,
-            child: OverflowBox(
-              minWidth: width,
-              maxWidth: width,
-              minHeight: height,
-              maxHeight: height,
-              child: mapRoot,
+        return MapStateInheritedWidget(
+          mapState: mapState,
+          child: ClipRect(
+            child: Transform.rotate(
+              angle: angle,
+              child: OverflowBox(
+                minWidth: width,
+                maxWidth: width,
+                minHeight: height,
+                maxHeight: height,
+                child: mapRoot,
+              ),
             ),
           ),
         );
       } else {
-        return mapRoot;
+        return MapStateInheritedWidget(
+          mapState: mapState,
+          child: mapRoot,
+        );
       }
     });
   }

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/src/core/bounds.dart';
 import 'package:flutter_map/src/core/center_zoom.dart';
 import 'package:flutter_map/src/core/point.dart';
+import 'package:flutter_map/src/map/map_state_widget.dart';
 import 'package:latlong/latlong.dart';
 
 class MapControllerImpl implements MapController {
@@ -105,6 +106,10 @@ class MapState {
 
   void dispose() {
     _onMoveSink.close();
+  }
+
+  void forceRebuild() {
+    _onMoveSink?.add(null);
   }
 
   void move(LatLng center, double zoom, {hasGesture = false}) {
@@ -276,5 +281,15 @@ class MapState {
     var pixelCenter = project(center, zoom).floor();
     var halfSize = size / (scale * 2);
     return Bounds(pixelCenter - halfSize, pixelCenter + halfSize);
+  }
+
+  static MapState of(BuildContext context, {bool nullOk = false}) {
+    assert(context != null);
+    assert(nullOk != null);
+    final widget = context.dependOnInheritedWidgetOfExactType<MapStateInheritedWidget>();
+    if (nullOk || widget != null) {
+      return widget?.mapState;
+    }
+    throw FlutterError('MapState.of() called with a context that does not contain a FlutterMap.');
   }
 }

--- a/lib/src/map/map_state_widget.dart
+++ b/lib/src/map/map_state_widget.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+import 'map.dart';
+
+class MapStateInheritedWidget extends InheritedWidget {
+  final MapState mapState;
+
+  MapStateInheritedWidget({
+    Key key,
+    @required this.mapState,
+    @required Widget child,
+  }) : super(key: key, child: child);
+
+  @override
+  bool updateShouldNotify(MapStateInheritedWidget oldWidget) {
+    return oldWidget.mapState.zoom == mapState.zoom &&
+        oldWidget.mapState.center == mapState.center &&
+        oldWidget.mapState.bounds == mapState.bounds &&
+        oldWidget.mapState.rotation == mapState.rotation;
+  }
+
+  static MapStateInheritedWidget of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<MapStateInheritedWidget>();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,9 @@ name: flutter_map
 description: A Dart implementation of Leaflet for Flutter apps
 version: 0.9.0
 homepage: https://github.com/johnpryan/flutter_map
-
+module:
+  androidX: true
+  
 environment:
   sdk: ">=2.6.0 <3.0.0"
   flutter: ^1.10.15


### PR DESCRIPTION
@johnpryan 

> I rewrite all my last PR 
> Compatible with plugins and can combine last way to use layers (with LayerOptions).

---

🎸 **No breaking changes**

---


🤖 _What's inside?_
- Adding `MapState.of(context)` to get the current MapState
- Adding `forceRebuild` method on MapState for rebuild all map
- Can use simple widget with FlutterMap now with the new property `children`
- Fix initState/dispose lifecyle -> called after TileLayer code

📜 _More explanation_

__What the sort in stack with children and layers?__
`children` property is before `layers` property in stack of Widget.

__I want create a simple plugin, how?__
Use simple Flutter Widget, example `Text("I'm a simple plugin now")`

__I want create a plugin who can access to mapState, how?__
Create a Flutter Widget with `MapState.of(context)` to get the current mapState.


🆘  _Linked issues_
Close #535
Close #459
Close #482