### PR TITLE
Edit Mapbox example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Widget build(BuildContext context) {
     layers: [
       new TileLayerOptions(
         urlTemplate: "https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}"
-            "{id}/{z}/{x}/{y}@2x.png?access_token={accessToken}",
         zoomOffset: -1,
         tileSize: 512,
         additionalOptions: {

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Widget build(BuildContext context) {
     ),
     layers: [
       new TileLayerOptions(
-        urlTemplate: "https://api.tiles.mapbox.com/v4/"
+        urlTemplate: "https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}"
             "{id}/{z}/{x}/{y}@2x.png?access_token={accessToken}",
+        zoomOffset: -1,
+        tileSize: 512,
         additionalOptions: {
           'accessToken': '<PUT_ACCESS_TOKEN_HERE>',
-          'id': 'mapbox.streets',
+          'id': 'mapbox/streets-v11',
         },
       ),
       new MarkerLayerOptions(


### PR DESCRIPTION
The Mapbox service has changed a bit and the URL and style id provided in the actual README are now deprecated, as stated in [this page](https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/).

Other cool mapbox styles can be found [here](https://docs.mapbox.com/mapbox-gl-js/example/setstyle/).

It's my first contribution to this project so I hope my PR respects your standards and will help the community.