### PR TITLE
Initialize map widgets with bounds or center

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Widget build(BuildContext context) {
 }
 ```
 
+Alternatively initialize the map by specifying bounds instead of center and zoom.
+
+```dart
+MapOptions(
+  bounds: LatLngBounds(LatLng(58.8, 6.1), LatLng(59, 6.2)),
+  boundsOptions: FitBoundsOptions(padding: EdgeInsets.all(8.0)),
+),
+```
+
 ### Azure Maps provider
 
 Configure the map to use [Azure Maps](https://azure.com/maps) by using the following `MapOptions` and layer options:

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -94,7 +94,9 @@ typedef void LongPressCallback(LatLng point);
 typedef void PositionCallback(MapPosition position, bool hasGesture);
 
 /// Allows you to provide your map's starting properties for [zoom], [rotation]
-/// and [center].
+/// and [center]. Alternatively you can provide [bounds] instead of [center].
+/// If both, [center] and [bounds] are provided, bounds will take preference 
+/// over [center].
 /// Zoom, pan boundary and interactivity constraints can be specified here too.
 ///
 /// Callbacks for [onTap], [onLongPress] and [onPositionChanged] can be
@@ -119,12 +121,16 @@ class MapOptions {
   final PositionCallback onPositionChanged;
   final List<MapPlugin> plugins;
   LatLng center;
+  LatLngBounds bounds;
+  FitBoundsOptions boundsOptions;
   LatLng swPanBoundary;
   LatLng nePanBoundary;
 
   MapOptions({
     this.crs = const Epsg3857(),
     this.center,
+    this.bounds,
+    this.boundsOptions = const FitBoundsOptions(),
     this.zoom = 13.0,
     this.rotation = 0.0,
     this.minZoom,

--- a/lib/flutter_map.dart
+++ b/lib/flutter_map.dart
@@ -89,13 +89,13 @@ abstract class MapController {
   factory MapController() => MapControllerImpl();
 }
 
-typedef void TapCallback(LatLng point);
-typedef void LongPressCallback(LatLng point);
-typedef void PositionCallback(MapPosition position, bool hasGesture);
+typedef TapCallback = void Function(LatLng point);
+typedef LongPressCallback = void Function(LatLng point);
+typedef PositionCallback = void Function(MapPosition position, bool hasGesture);
 
 /// Allows you to provide your map's starting properties for [zoom], [rotation]
 /// and [center]. Alternatively you can provide [bounds] instead of [center].
-/// If both, [center] and [bounds] are provided, bounds will take preference 
+/// If both, [center] and [bounds] are provided, bounds will take preference
 /// over [center].
 /// Zoom, pan boundary and interactivity constraints can be specified here too.
 ///

--- a/lib/src/layer/tile_layer.dart
+++ b/lib/src/layer/tile_layer.dart
@@ -890,7 +890,8 @@ class _TileLayerState extends State<TileLayer> with TickerProviderStateMixin {
   }
 }
 
-typedef void TileReady(Coords<double> coords, dynamic error, Tile tile);
+typedef TileReady = void Function(
+    Coords<double> coords, dynamic error, Tile tile);
 
 class Tile implements Comparable<Tile> {
   final String coordsKey;
@@ -1003,7 +1004,7 @@ class AnimatedTile extends StatefulWidget {
   final Tile tile;
   final ImageProvider errorImage;
 
-  AnimatedTile({Key key, this.tile, this.errorImage})
+  AnimatedTile({Key key, @required this.tile, this.errorImage})
       : assert(null != tile),
         super(key: key);
 

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -100,7 +100,11 @@ class MapState {
   Bounds get pixelBounds => getLastPixelBounds();
 
   void _init() {
-    move(options.center, zoom);
+    if (options.bounds != null) {
+      fitBounds(options.bounds, options.boundsOptions);
+    } else {
+      move(options.center, zoom);
+    }
   }
 
   void dispose() {

--- a/lib/src/map/map.dart
+++ b/lib/src/map/map.dart
@@ -251,18 +251,18 @@ class MapState {
 
   double getZoomScale(double toZoom, double fromZoom) {
     var crs = options.crs;
-    fromZoom = fromZoom == null ? _zoom : fromZoom;
+    fromZoom = fromZoom ?? _zoom;
     return crs.scale(toZoom) / crs.scale(fromZoom);
   }
 
   double getScaleZoom(double scale, double fromZoom) {
     var crs = options.crs;
-    fromZoom = fromZoom == null ? _zoom : fromZoom;
+    fromZoom = fromZoom ?? _zoom;
     return crs.zoom(scale * crs.scale(fromZoom));
   }
 
   Bounds getPixelWorldBounds(double zoom) {
-    return options.crs.getProjectedBounds(zoom == null ? _zoom : zoom);
+    return options.crs.getProjectedBounds(zoom ?? _zoom);
   }
 
   CustomPoint getPixelOrigin() {


### PR DESCRIPTION
I had the need to init a map widget by providing bounds to to constructor. 
The way it works is you just provide bounds and boundsOptions instead of the center. If no bounds are provided, the library will work as in the past by using the center. This change is backwards compatible.

This problem was discussed in https://github.com/johnpryan/flutter_map/issues/255