### PR TITLE
fix/group-layer-rebuid: consuming rebuild stream in group layer

### DIFF
--- a/lib/src/layer/group_layer.dart
+++ b/lib/src/layer/group_layer.dart
@@ -27,14 +27,20 @@ class GroupLayer extends StatelessWidget {
   }
 
   Widget _build(BuildContext context) {
-    var layers = <Widget>[
-      for (var options in groupOpts.group) _createLayer(options)
-    ];
+    return StreamBuilder(
+      stream: stream,
+      builder: (BuildContext context, _) {
 
-    return Container(
-      child: Stack(
-        children: layers,
-      ),
+        var layers = <Widget>[
+          for (var options in groupOpts.group) _createLayer(options)
+        ];
+
+        return Container(
+          child: Stack(
+            children: layers,
+          ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
The rebuild group stream created in `flutter_map_state.dart` isn't being consumed in the group layer, in my case causing polygons and markers to be shown where they aren't because those layers aren't being rebuilt.

The stream passed down to the layers inside the group layer are only the `option.rebuild` stream of each specific layer, and those streams are only populated when the dev is instantiating the `LayerOption` for that layer. I added a stream builder to rebuild all the layers inside the group layer, and left the current way the other layers are being handled, case the dev wants to rebuild a specific layer with that layers `option.rebuild` field.